### PR TITLE
Fixed grunt compilation issue

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
         requiresConfig: 'git-revision',
         files: {
           "gen/axs_testing.js": [
-              "./lib/closure-library/closure/goog/base.js",
+              "./lib/closure/base.js",
               "./src/js/axs.js",
               "./src/js/BrowserUtils.js",
               "./src/js/Constants.js",


### PR DESCRIPTION
This fixes an issue when trying to compile with grunt for the first time. Because of a pathing issue, we get:

Warning: ./src/js/AuditResults.js:36: ERROR - variable goog is undeclared
goog.exportSymbol('axs.AuditResults', axs.AuditResults);
