### PR TITLE
Move check for name-from:content out of getTextFromDescendantContent and...

### DIFF
--- a/src/audits/MainRoleOnInappropriateElement.js
+++ b/src/audits/MainRoleOnInappropriateElement.js
@@ -31,7 +31,7 @@ axs.AuditRule.specs.mainRoleOnInappropriateElement = {
     test: function(element) {
         if (axs.utils.isInlineElement(element))
             return true;
-        var computedTextContent = axs.properties.findTextAlternatives(element, {});
+        var computedTextContent = axs.properties.getTextFromDescendantContent(element);
         if (!computedTextContent || computedTextContent.length < 50)
             return true;
 

--- a/src/js/Properties.js
+++ b/src/js/Properties.js
@@ -255,8 +255,17 @@ axs.properties.findTextAlternatives = function(node, textAlternatives, opt_recur
 
     // 2C. Otherwise, if the attributes checked in rules A and B didn't provide results, text is
     // collected from descendant content if the current element's role allows "Name From: contents."
+    var hasRole = element.hasAttribute('role');
+    var canGetNameFromContents = true;
+    if (hasRole) {
+        var roleName = element.getAttribute('role');
+        // if element has a role, check that it allows "Name From: contents"
+        var role = axs.constants.ARIA_ROLES[roleName];
+        if (role && (!role.namefrom || role.namefrom.indexOf('contents') < 0))
+            canGetNameFromContents = false;
+    }
     var textFromContent = axs.properties.getTextFromDescendantContent(element);
-    if (textFromContent) {
+    if (textFromContent && canGetNameFromContents) {
         var textFromContentValue = {};
         textFromContentValue.type = 'text';
         textFromContentValue.text = textFromContent;
@@ -294,15 +303,6 @@ axs.properties.findTextAlternatives = function(node, textAlternatives, opt_recur
  * @return {?string}
  */
 axs.properties.getTextFromDescendantContent = function(element) {
-    var hasRole = element.hasAttribute('role');
-    if (hasRole) {
-        var roleName = element.getAttribute('role');
-        // if element has a role, check that it allows "Name From: contents"
-        var role = axs.constants.ARIA_ROLES[roleName];
-        if (role && (!role.namefrom || role.namefrom.indexOf('contents') < 0))
-            return null;
-    }
-    // Also get text from descendant contents if there is no role - e.g. p, span or div
     var children = element.childNodes;
     var childrenTextContent = [];
     for (var i = 0; i < children.length; i++) {


### PR DESCRIPTION
... use getTextFromDescendantContent instead of getTextAlternatives in MainRoleOnInappropriateElement test

This was previously committed but got clobbered by a later commit.

Fixes bug reported here: https://groups.google.com/forum/#!category-topic/introduction-to-web-accessibility/ChGzBSe0_yU
