### PR TITLE
Check for body element in axs.utils.canScrollTo()

### DIFF
--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -175,7 +175,7 @@ axs.utils.canScrollTo = function(element, container) {
 
     if (rect.left > containerRect.right || rect.top > containerRect.bottom) {
         return (style.overflow == 'scroll' || style.overflow == 'auto' ||
-                container.tagName.toLowerCase() == 'body');
+                container instanceof defaultView.HTMLBodyElement);
     }
 
     return true;


### PR DESCRIPTION
Slight amendment: canScrollTo() method needs to explicitly check whether the container element is the body element, as its visible area can be larger than its bounding box (but will be equal to its scroll area) if it has floating elements.
