### PR TITLE
Fail if an input has a placeholder but no label.

### DIFF
--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -967,9 +967,6 @@ axs.utils.hasLabel = function(element) {
     if (element.hasAttribute('aria-labelledby'))
         return true;
 
-    if (axs.utils.isNativeTextElement(element) && element.hasAttribute('placeholder'))
-        return true;
-
     if (element.hasAttribute('id')) {
         var labelsFor = document.querySelectorAll('label[for="' + element.id + '"]');
         if (labelsFor.length > 0)

--- a/test/js/utils-test.js
+++ b/test/js/utils-test.js
@@ -93,25 +93,19 @@ test("Input type=submit has a label.", function() {
   element.type = "submit";
   equal(axs.utils.hasLabel(element), true);
 });
-test("A placeholder counts a label.", function() {
+test("A placeholder does not count as a label.", function() {
   var element0 = document.createElement("textarea");
   element0.placeholder = "Your life story";
-  equal(axs.utils.hasLabel(element0), true);
+  equal(axs.utils.hasLabel(element0), false);
 
   var element1 = document.createElement("input");
   element1.placeholder = "First name";
-  equal(axs.utils.hasLabel(element1), true);
+  equal(axs.utils.hasLabel(element1), false);
 
   var element2 = document.createElement("input");
   element2.type = "url";
   element2.placeholder = "Homepage";
-  equal(axs.utils.hasLabel(element2), true);
-
-  // This one fails, a checkbox can't have a placeholder.
-  var element3 = document.createElement("input");
-  element3.type = "checkbox";
-  element3.placeholder = "Add me to your mailing list";
-  equal(axs.utils.hasLabel(element3), false);
+  equal(axs.utils.hasLabel(element2), false);
 });
 test('axs.utils.hasLabel() does not crash for element with numeric id attribute', function() {
     var element = document.createElement('input');


### PR DESCRIPTION
A `placeholder` attribute is not a substitute for a proper label

[Closes #81]
