### PR TITLE
Controls with role="presentation" do not need labels.

### DIFF
--- a/src/audits/ControlsWithoutLabel.js
+++ b/src/audits/ControlsWithoutLabel.js
@@ -33,7 +33,7 @@ axs.AuditRule.specs.controlsWithoutLabel = {
                                 'button:not([disabled])',
                                 'video:not([disabled])'].join(', ');
         var isControl = axs.browserUtils.matchSelector(element, controlsSelector);
-        if (!isControl)
+        if (!isControl || element.getAttribute('role') == 'presentation')
             return false;
         if (element.tabIndex >= 0)
             return true;

--- a/test/audits/controls-without-label-test.js
+++ b/test/audits/controls-without-label-test.js
@@ -55,3 +55,24 @@ test('Input type button with value needs no label', function() {
     equal(rule.run({ scope: fixture }).result,
           axs.constants.AuditResult.PASS);
 });
+
+test('Input with role="presentation" needs no label', function() {
+    var fixture = document.getElementById('qunit-fixture');
+
+    var input = document.createElement('input');
+    var select = document.createElement('select');
+    var textarea = document.createElement('textarea');
+    var button = document.createElement('button');
+    var video = document.createElement('video');
+
+    var controls = [input, select, textarea, button, video];
+
+    controls.forEach(function(control) {
+      control.setAttribute("role", "presentation");
+      fixture.appendChild(control);
+    });
+
+    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
+    equal(rule.run({ scope: fixture }).result,
+          axs.constants.AuditResult.NA);
+});


### PR DESCRIPTION
Adding role="presentation" is an explicit declaration by the developer to hide the elements native semantics from the accessibility API, and thus should be ignored.

http://www.w3.org/TR/wai-aria/roles#presentation

[Closes #23]
