### PR TITLE
Warn on positive integer tabIndex values.

### DIFF
--- a/src/audits/TabIndexGreaterThanZero.js
+++ b/src/audits/TabIndexGreaterThanZero.js
@@ -1,0 +1,36 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.require('axs.AuditRule');
+goog.require('axs.constants.Severity');
+
+/**
+ * @type {axs.AuditRule.Spec}
+ */
+
+axs.AuditRule.specs.tabIndexGreaterThanZero = {
+    name: "tabIndexGreaterThanZero",
+    heading: "Avoid positive integer values for tabIndex",
+    url: "https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_03--avoid-positive-integer-values-for-tabindex",
+    severity: axs.constants.Severity.WARNING,
+    relevantElementMatcher: function(element) {
+      var selector = "[tabindex]";
+      return axs.browserUtils.matchSelector(element, selector);
+    },
+    test: function(element) {
+      if(element.tabIndex > 0)
+        return true;
+    },
+    code: 'AX_FOCUS_03'
+};

--- a/test/audits/tab-index-greater-than-zero-test.js
+++ b/test/audits/tab-index-greater-than-zero-test.js
@@ -1,0 +1,43 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module("tabIndex values");
+
+test("tabIndex is 0 or -1 passes the audit", function() {
+  var rule = axs.AuditRules.getRule("tabIndexGreaterThanZero");
+  var fixture = document.getElementById('qunit-fixture');
+
+  var listItem = document.createElement("li");
+  var heading = document.createElement("h2");
+  fixture.appendChild(listItem);
+  fixture.appendChild(heading);
+  listItem.tabIndex = -1;
+  heading.tabIndex = 0;
+
+  var output = rule.run({ scope: fixture });
+  equal(output.result, axs.constants.AuditResult.PASS);
+});
+
+test("tabIndex with a positive integer fails the audit", function() {
+  var rule = axs.AuditRules.getRule("tabIndexGreaterThanZero");
+  var fixture = document.getElementById('qunit-fixture');
+
+  var listItem = document.createElement("li");
+  fixture.appendChild(listItem);
+  listItem.tabIndex = 1;
+
+  var output = rule.run({ scope: fixture });
+  equal(output.result, axs.constants.AuditResult.FAIL);
+  deepEqual(output.elements, [listItem]);
+});

--- a/test/index.html
+++ b/test/index.html
@@ -30,6 +30,7 @@
     <script src="../src/audits/NonExistentAriaRelatedElement.js"></script>
     <script src="../src/audits/PageWithoutTitle.js"></script>
     <script src="../src/audits/RequiredAriaAttributeMissing.js"></script>
+    <script src="../src/audits/TabIndexGreaterThanZero.js"></script>
     <script src="../src/audits/UnfocusableElementsWithOnClick.js"></script>
     <script src="../src/audits/VideoWithoutCaptions.js"></script>
 
@@ -49,6 +50,7 @@
     <script src="./audits/non-existent-aria-related-element-test.js"></script>
     <script src="./audits/page-without-title-test.js"></script>
     <script src="./audits/required-aria-attribute-missing-test.js"></script>
+    <script src="./audits/tab-index-greater-than-zero-test.js"></script>
   </head>
   <body>
     <h1 id="qunit-header">Test Accessibility Extension</h1>


### PR DESCRIPTION
Setting positive values creates a mismatch between tab order and reading order. This is confusing for screen reader users

[Closes #109]
