### PR TITLE
Calculate low contrast based on WCAG recommended sizes.

### DIFF
--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -362,39 +362,9 @@ axs.utils.isLargeFont = function(style) {
     var matches = fontSize.match(/(\d+)px/);
     if (matches) {
         var fontSizePx = parseInt(matches[1], 10);
-        var bodyStyle = window.getComputedStyle(document.body, null);
-        var bodyFontSize = bodyStyle.fontSize;
-        matches = bodyFontSize.match(/(\d+)px/);
-        if (matches) {
-            var bodyFontSizePx = parseInt(matches[1], 10);
-            var boldLarge = bodyFontSizePx * 1.2;
-            var large = bodyFontSizePx * 1.5;
-        } else {
-            var boldLarge = 19.2;
-            var large = 24;
-        }
+        var boldLarge = 14;
+        var large = 18;
         return (bold && fontSizePx >= boldLarge || fontSizePx >= large);
-    }
-    matches = fontSize.match(/(\d+)em/);
-    if (matches) {
-        var fontSizeEm = parseInt(matches[1], 10);
-        if (bold && fontSizeEm >= 1.2 || fontSizeEm >= 1.5)
-            return true;
-        return false;
-    }
-    matches = fontSize.match(/(\d+)%/);
-    if (matches) {
-        var fontSizePercent = parseInt(matches[1], 10);
-        if (bold && fontSizePercent >= 120 || fontSizePercent >= 150)
-            return true;
-        return false;
-    }
-    matches = fontSize.match(/(\d+)pt/);
-    if (matches) {
-        var fontSizePt = parseInt(matches[1], 10);
-        if (bold && fontSizePt >= 14 || fontSizePt >= 18)
-            return true;
-        return false;
     }
     return false;
 };

--- a/test/audits/low-contrast-test.js
+++ b/test/audits/low-contrast-test.js
@@ -38,6 +38,49 @@ test("Low contrast = fail", function() {
   );
 });
 
+test("> 3:1 and < 4.5:1 contrast for large text passes", function() {
+  var fixture = document.getElementById('qunit-fixture');
+  var div = document.createElement('div');
+  div.style.backgroundColor = '#fafafa';
+  div.style.color = '#777';  // Contrast ratio approx 4.3
+  div.textContent = 'Some text';
+  div.style.fontSize = "19px"
+  fixture.appendChild(div);
+  deepEqual(
+    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
+    { elements: [], result: axs.constants.AuditResult.PASS }
+  );
+});
+
+test("> 3:1 and < 4.5:1 contrast for bold text passes", function() {
+  var fixture = document.getElementById('qunit-fixture');
+  var div = document.createElement('div');
+  div.style.backgroundColor = '#fafafa';
+  div.style.color = '#777';  // Contrast ratio approx 4.3
+  div.textContent = 'Some text';
+  div.style.fontSize = "15px"
+  div.style.fontWeight = "bold"
+  fixture.appendChild(div);
+  deepEqual(
+    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
+    { elements: [], result: axs.constants.AuditResult.PASS }
+  );
+});
+
+test("< 4.5 contrast for regular text fails", function() {
+  var fixture = document.getElementById('qunit-fixture');
+  var div = document.createElement('div');
+  div.style.backgroundColor = '#fafafa';
+  div.style.color = '#777';  // Contrast ratio approx 4.3
+  div.textContent = 'Some text';
+  div.style.fontSize = "13px"
+  fixture.appendChild(div);
+  deepEqual(
+    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
+    { elements: [div], result: axs.constants.AuditResult.FAIL }
+  );
+});
+
 test("Opacity is handled", function() {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');


### PR DESCRIPTION
- Assumes font size from computed styles is always in px
- Use WCAG recommended px values for large fonts (18px or 14px bold)

[Closes #122]
