### PR TITLE
Fixing issue #126 and adding unit tests for it.

### DIFF
--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -134,55 +134,49 @@ axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
     if (element && matcher.call(null, element))
         collection.push(element);
 
-    // Descend into node:
-    // If it has a ShadowRoot, ignore all child elements - these will be picked
-    // up by the <content> or <shadow> elements. Descend straight into the
-    // ShadowRoot.
+    // Descend into node
     if (element) {
-        var shadowRoot = element.shadowRoot || element.webkitShadowRoot;
-        if (shadowRoot) {
-            axs.AuditRule.collectMatchingElements(shadowRoot,
-                                                  matcher,
-                                                  collection,
-                                                  shadowRoot);
-            return;
-        }
-    }
-
-    // If it is a <content> element, descend into distributed elements - descend
-    // into distributed elements - these are elements from outside the shadow
-    // root which are rendered inside the shadow DOM.
-    if (element && element.localName == 'content') {
-        var content = /** @type {HTMLContentElement} */ (element);
-        var distributedNodes = content.getDistributedNodes();
-        for (var i = 0; i < distributedNodes.length; i++) {
-            axs.AuditRule.collectMatchingElements(distributedNodes[i],
-                                                  matcher,
-                                                  collection,
-                                                  opt_shadowRoot);
-        }
-        return;
-    }
-
-    // If it is a <shadow> element, descend into the olderShadowRoot of the
-    // current ShadowRoot.
-    if (element && element.localName == 'shadow') {
-        var shadow = /** @type {HTMLShadowElement} */ (element);
-        if (!opt_shadowRoot) {
-            console.warn('ShadowRoot not provided for', element);
-        } else {
-            var olderShadowRoot = opt_shadowRoot.olderShadowRoot ||
-                                  shadow.olderShadowRoot;
-            if (olderShadowRoot) {
-                axs.AuditRule.collectMatchingElements(olderShadowRoot,
+        if (element.localName == 'content') {
+            // If it is a <content> element, descend into distributed elements - descend
+            // into distributed elements - these are elements from outside the shadow
+            // root which are rendered inside the shadow DOM.
+            var content = /** @type {HTMLContentElement} */ (element);
+            var distributedNodes = content.getDistributedNodes();
+            for (var i = 0; i < distributedNodes.length; i++) {
+                axs.AuditRule.collectMatchingElements(distributedNodes[i],
                                                       matcher,
                                                       collection,
-                                                      olderShadowRoot);
+                                                      opt_shadowRoot);
+            }
+            return;
+        } else if (element.localName == 'shadow') {
+            // If it is a <shadow> element, descend into the olderShadowRoot of the
+            // current ShadowRoot.
+            var shadow = /** @type {HTMLShadowElement} */ (element);
+            if (!opt_shadowRoot) {
+                console.warn('ShadowRoot not provided for', element);
+            } else {
+                var olderShadowRoot = opt_shadowRoot.olderShadowRoot ||
+                                      shadow.olderShadowRoot;
+                if (olderShadowRoot) {
+                    axs.AuditRule.collectMatchingElements(olderShadowRoot,
+                                                          matcher,
+                                                          collection,
+                                                          olderShadowRoot);
+                }
+            }
+            return;
+        } else {
+            var shadowRoot = element.shadowRoot || element.webkitShadowRoot;
+            if (shadowRoot) {
+                axs.AuditRule.collectMatchingElements(shadowRoot,
+                                                      matcher,
+                                                      collection,
+                                                      shadowRoot);
             }
         }
-        return;
+        
     }
-
     // If it is neither the parent of a ShadowRoot, a <content> element, nor
     // a <shadow> element recurse normally.
     var child = node.firstChild;

--- a/test/index.html
+++ b/test/index.html
@@ -40,6 +40,7 @@
     <script src="./js/utils-test.js"></script>
     <script src="./js/browser-utils-test.js"></script>
     <script src="./js/audit-configuration-test.js"></script>
+    <script src="./js/audit-rule-test.js"></script>
     <script src="./audits/aria-owns-descendant-test.js"></script>
     <script src="./audits/bad-aria-role-test.js"></script>
     <script src="./audits/bad-aria-attribute-value-test.js"></script>

--- a/test/js/audit-rule-test.js
+++ b/test/js/audit-rule-test.js
@@ -1,0 +1,90 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+(function(){
+    module("collectMatchingElements");
+
+    var DIV_COUNT = 10;
+    function matcher(element) {
+        var tagName = element.tagName;
+        if (!tagName)
+            return false;
+        return (tagName.toLowerCase() === "div" && element.classList.contains("test"));
+    }
+
+    function buildTestDom() {
+        var result = document.createDocumentFragment();
+        result = result.appendChild(document.createElement("div"));
+        for (var i = 0; i < DIV_COUNT; i++) {
+            var element = document.createElement("div");
+            element.className = "test";
+            result.appendChild(element);
+        }
+        return result;
+    }
+
+    test("Simple DOM", function () {
+        var container = document.getElementById('qunit-fixture');
+        container.appendChild(buildTestDom());
+        var matched = [];
+        axs.AuditRule.collectMatchingElements(container, matcher, matched);
+        equal(matched.length, DIV_COUNT);
+    });
+
+    test("With shadow DOM", function () {
+        var container = document.getElementById('qunit-fixture');
+        container.appendChild(buildTestDom());
+        var wrapper = container.firstElementChild;
+        if (wrapper.createShadowRoot) {
+            var matched = [];
+            wrapper.createShadowRoot();
+            axs.AuditRule.collectMatchingElements(wrapper, matcher, matched);
+            equal(matched.length, DIV_COUNT);
+        } else {
+            console.warn("Test platform does not support shadow DOM");
+            ok(true);
+        }
+    });
+
+    test("Nodes within shadow DOM", function () {
+        var container = document.getElementById('qunit-fixture');
+        var wrapper = container.appendChild(document.createElement("div"));
+        if (wrapper.createShadowRoot) {
+            var root = wrapper.createShadowRoot();
+            root.appendChild(buildTestDom());
+            var matched = [];
+            axs.AuditRule.collectMatchingElements(container, matcher, matched);
+            equal(matched.length, DIV_COUNT);
+        } else {
+            console.warn("Test platform does not support shadow DOM");
+            ok(true);
+        }
+    });
+
+    test("Nodes within DOM and shadow DOM", function () {
+        var container = document.getElementById('qunit-fixture');
+        var wrapper = container.appendChild(document.createElement("div"));
+        if (wrapper.createShadowRoot) {
+            var root = wrapper.createShadowRoot();
+            root.appendChild(buildTestDom());
+            var matched = [];
+            wrapper.appendChild(buildTestDom());
+            axs.AuditRule.collectMatchingElements(container, matcher, matched);
+            equal(matched.length, (DIV_COUNT * 2));
+        } else {
+            console.warn("Test platform does not support shadow DOM");
+            ok(true);
+        }
+    });
+
+})();


### PR DESCRIPTION
This bug only affects browsers that support shadow DOM therefore unit tests must be on an affected platform (e.g. Chrome browser) or they are essentially no-op.