### PR TITLE
Tighten up the mechanisms for registering/accessing audit rules.

### DIFF
--- a/src/audits/AriaOnReservedElement.js
+++ b/src/audits/AriaOnReservedElement.js
@@ -19,9 +19,8 @@ goog.require('axs.properties');
 
 /**
  * Based on recommendations in document: http://www.w3.org/TR/aria-in-html/
- * @type {axs.AuditRule.Spec}
  */
-axs.AuditRule.specs.ariaOnReservedElement = {
+axs.AuditRules.addRule({
     name: 'ariaOnReservedElement',
     heading: 'This element does not support ARIA roles, states and properties',
     url: '',
@@ -33,4 +32,4 @@ axs.AuditRule.specs.ariaOnReservedElement = {
         return axs.properties.getAriaProperties(element) !== null;
     },
     code: 'AX_ARIA_12'
-};
+});

--- a/src/audits/AriaOwnsDescendant.js
+++ b/src/audits/AriaOwnsDescendant.js
@@ -17,9 +17,9 @@ goog.require('axs.AuditRules');
 goog.require('axs.constants.Severity');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This test checks that aria-owns does not reference an element that is already owned implicitly.
  */
-axs.AuditRule.specs.ariaOwnsDescendant = {
+axs.AuditRules.addRule({
     // TODO(RickSBrown): check for elements that try to 'aria-own' an ancestor;
     // Also: own self does not make sense. Perhaps any IDREF pointing to itself is bad?
     // Perhaps even extend this beyond ARIA (e.g. label for itself). Have to change return code?
@@ -39,4 +39,4 @@ axs.AuditRule.specs.ariaOwnsDescendant = {
         });
     },
     code: 'AX_ARIA_06'
-};
+});

--- a/src/audits/AriaRoleNotScoped.js
+++ b/src/audits/AriaRoleNotScoped.js
@@ -20,10 +20,8 @@ goog.require('axs.constants');
  * This test checks ARIA roles which must be owned by another role.
  *    For example a role of `tab` can only exist within a `tablist`.
  *    This ownership can be represented implicitly by DOM hierarchy or explictly through the `aria-owns` attribute.
- *
- * @type {axs.AuditRule.Spec}
  */
-axs.AuditRule.specs.ariaRoleNotScoped = {
+axs.AuditRules.addRule({
     name: 'ariaRoleNotScoped',
     heading: 'Elements with ARIA roles must be in the correct scope',
     url: '',
@@ -71,4 +69,4 @@ axs.AuditRule.specs.ariaRoleNotScoped = {
         return true;
     },
     code: 'AX_ARIA_09'
-};
+});

--- a/src/audits/AudioWithoutControls.js
+++ b/src/audits/AudioWithoutControls.js
@@ -16,9 +16,9 @@ goog.require('axs.AuditRule');
 goog.require('axs.constants.Severity');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This audit flags any audio elements that do not have controls.
  */
-axs.AuditRule.specs.audioWithoutControls = {
+axs.AuditRules.addRule({
     name: 'audioWithoutControls',
     heading: 'Audio elements should have controls',
     url: '',
@@ -31,4 +31,4 @@ axs.AuditRule.specs.audioWithoutControls = {
         return !controls.length && audio.duration > 3;
     },
     code: 'AX_AUDIO_01'
-};
+});

--- a/src/audits/BadAriaAttribute.js
+++ b/src/audits/BadAriaAttribute.js
@@ -31,7 +31,7 @@ goog.require('axs.constants');
      *
      * @type {axs.AuditRule.Spec}
      */
-    axs.AuditRule.specs.badAriaAttribute = {
+    var badAriaAttribute = {
         name: 'badAriaAttribute',
         heading: 'This element has an invalid ARIA attribute',
         url: '',
@@ -60,4 +60,5 @@ goog.require('axs.constants');
         },
         code: 'AX_ARIA_11'
     };
+    axs.AuditRules.addRule(badAriaAttribute);
 })();

--- a/src/audits/BadAriaAttributeValue.js
+++ b/src/audits/BadAriaAttributeValue.js
@@ -18,9 +18,9 @@ goog.require('axs.constants');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This audit checks the values of ARIA states and properties to ensure they are valid.
  */
-axs.AuditRule.specs.badAriaAttributeValue = {
+axs.AuditRules.addRule({
     name: 'badAriaAttributeValue',
     heading: 'ARIA state and property values must be valid',
     url: '',
@@ -42,4 +42,4 @@ axs.AuditRule.specs.badAriaAttributeValue = {
         return false;
     },
     code: 'AX_ARIA_04'
-};
+});

--- a/src/audits/BadAriaRole.js
+++ b/src/audits/BadAriaRole.js
@@ -17,9 +17,9 @@ goog.require('axs.AuditRules');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This audit checks the `role` attribute to ensure it contains a valid, non-abstract ARIA role.
  */
-axs.AuditRule.specs.badAriaRole = {
+axs.AuditRules.addRule({
     name: 'badAriaRole',
     heading: 'Elements with ARIA roles must use a valid, non-abstract ARIA role',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_01--elements-with-aria-roles-must-use-a-valid-non-abstract-aria-role',
@@ -32,4 +32,4 @@ axs.AuditRule.specs.badAriaRole = {
         return !roles.valid;
     },
     code: 'AX_ARIA_01'
-};
+});

--- a/src/audits/ControlsWithoutLabel.js
+++ b/src/audits/ControlsWithoutLabel.js
@@ -19,9 +19,9 @@ goog.require('axs.constants.Severity');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This audit checks that form controls and media elements have labels.
  */
-axs.AuditRule.specs.controlsWithoutLabel = {
+axs.AuditRules.addRule({
     name: 'controlsWithoutLabel',
     heading: 'Controls and media elements should have labels',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_text_01--controls-and-media-elements-should-have-labels',
@@ -66,4 +66,4 @@ axs.AuditRule.specs.controlsWithoutLabel = {
     },
     code: 'AX_TEXT_01',
     ruleName: 'Controls and media elements should have labels'
-};
+});

--- a/src/audits/DuplicateId.js
+++ b/src/audits/DuplicateId.js
@@ -17,9 +17,9 @@ goog.require('axs.AuditRules');
 goog.require('axs.constants.Severity');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This audit checks for duplicate IDs in the DOM.
  */
-axs.AuditRule.specs.duplicateId = {
+axs.AuditRules.addRule({
     name: 'duplicateId',
     heading: 'An element\'s ID must be unique in the DOM',
     url: '',
@@ -45,4 +45,4 @@ axs.AuditRule.specs.duplicateId = {
         return (elementsWithId.length > 1);
     },
     code: 'AX_HTML_02'
-};
+});

--- a/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
+++ b/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
@@ -19,9 +19,9 @@ goog.require('axs.constants.Severity');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * This audit checks for elements that are focusable but invisible or obscured by another element.
  */
-axs.AuditRule.specs.focusableElementNotVisibleAndNotAriaHidden = {
+axs.AuditRules.addRule({
     name: 'focusableElementNotVisibleAndNotAriaHidden',
     heading: 'These elements are focusable but either invisible or obscured by another element',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_01--these-elements-are-focusable-but-either-invisible-or-obscured-by-another-element',
@@ -53,7 +53,7 @@ axs.AuditRule.specs.focusableElementNotVisibleAndNotAriaHidden = {
         if (axs.utils.isElementOrAncestorHidden(element))
             return false;
         element.focus();
-        return !axs.utils.elementIsVisible(element)
+        return !axs.utils.elementIsVisible(element);
     },
     code: 'AX_FOCUS_01'
-};
+});

--- a/src/audits/HumanLangMissing.js
+++ b/src/audits/HumanLangMissing.js
@@ -15,10 +15,7 @@
 goog.require('axs.AuditRule');
 goog.require('axs.constants.Severity');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.humanLangMissing = {
+axs.AuditRules.addRule({
     name: 'humanLangMissing',
     heading: 'The web page should have the content\'s human language indicated in the markup',
     url: '',
@@ -32,4 +29,4 @@ axs.AuditRule.specs.humanLangMissing = {
         return false;
     },
     code: 'AX_HTML_01'
-};
+});

--- a/src/audits/ImageWithoutAltText.js
+++ b/src/audits/ImageWithoutAltText.js
@@ -17,10 +17,7 @@ goog.require('axs.AuditRules');
 goog.require('axs.constants.Severity');
 goog.require('axs.utils');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.imagesWithoutAltText = {
+axs.AuditRules.addRule({
     name: 'imagesWithoutAltText',
     heading: 'Images should have an alt attribute',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_text_02--images-should-have-an-alt-attribute-unless-they-have-an-aria-role-of-presentation',
@@ -33,4 +30,4 @@ axs.AuditRule.specs.imagesWithoutAltText = {
         return (!image.hasAttribute('alt') && image.getAttribute('role') != 'presentation');
     },
     code: 'AX_TEXT_02'
-};
+});

--- a/src/audits/LinkWithUnclearPurpose.js
+++ b/src/audits/LinkWithUnclearPurpose.js
@@ -16,9 +16,9 @@ goog.require('axs.AuditRule');
 goog.require('axs.constants.Severity');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * The purpose of each link should be clear from the link text.
  */
-axs.AuditRule.specs.linkWithUnclearPurpose = {
+axs.AuditRules.addRule({
     name: 'linkWithUnclearPurpose',
     heading: 'The purpose of each link should be clear from the link text',
     url: '',
@@ -65,5 +65,5 @@ axs.AuditRule.specs.linkWithUnclearPurpose = {
         }
         return false;
     },
-    code: 'AX_TITLE_01'
-};
+    code: 'AX_TEXT_04'
+});

--- a/src/audits/LowContrast.js
+++ b/src/audits/LowContrast.js
@@ -19,9 +19,9 @@ goog.require('axs.properties');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * Text elements should have a reasonable contrast ratio
  */
-axs.AuditRule.specs.lowContrastElements = {
+axs.AuditRules.addRule({
     name: 'lowContrastElements',
     heading: 'Text elements should have a reasonable contrast ratio',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_color_01--text-elements-should-have-a-reasonable-contrast-ratio',
@@ -36,4 +36,4 @@ axs.AuditRule.specs.lowContrastElements = {
         return (contrastRatio && axs.utils.isLowContrast(contrastRatio, style));
     },
     code: 'AX_COLOR_01'
-};
+});

--- a/src/audits/MainRoleOnInappropriateElement.js
+++ b/src/audits/MainRoleOnInappropriateElement.js
@@ -18,9 +18,9 @@ goog.require('axs.properties');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * role=main should only appear on significant elements
  */
-axs.AuditRule.specs.mainRoleOnInappropriateElement = {
+axs.AuditRules.addRule({
     name: 'mainRoleOnInappropriateElement',
     heading: 'role=main should only appear on significant elements',
     url: '',
@@ -37,5 +37,5 @@ axs.AuditRule.specs.mainRoleOnInappropriateElement = {
 
         return false;
     },
-    code: 'AX_ARIA_04'
-};
+    code: 'AX_ARIA_05'
+});

--- a/src/audits/MeaningfulBackgroundImage.js
+++ b/src/audits/MeaningfulBackgroundImage.js
@@ -18,9 +18,9 @@ goog.require('axs.constants.Severity');
 goog.require('axs.utils');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * Meaningful images should not be used in element backgrounds.
  */
-axs.AuditRule.specs.elementsWithMeaningfulBackgroundImage = {
+axs.AuditRules.addRule({
     name: 'elementsWithMeaningfulBackgroundImage',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
@@ -44,4 +44,4 @@ axs.AuditRule.specs.elementsWithMeaningfulBackgroundImage = {
         return width < 150 && height < 150;
     },
     code: 'AX_IMAGE_01'
-};
+});

--- a/src/audits/MultipleAriaOwners.js
+++ b/src/audits/MultipleAriaOwners.js
@@ -17,9 +17,9 @@ goog.require('axs.AuditRules');
 goog.require('axs.constants.Severity');
 
 /**
- * @type {axs.AuditRule.Spec}
+ * An element's ID must not be present in more that one aria-owns attribute at any time.
  */
-axs.AuditRule.specs.multipleAriaOwners = {
+axs.AuditRules.addRule({
     name: 'multipleAriaOwners',
     heading: 'An element\'s ID must not be present in more that one aria-owns attribute at any time',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_07--an-element-can-have-only-one-explicit-aria-owner',
@@ -42,4 +42,4 @@ axs.AuditRule.specs.multipleAriaOwners = {
         });
     },
     code: 'AX_ARIA_07'
-};
+});

--- a/src/audits/NonExistentAriaRelatedElement.js
+++ b/src/audits/NonExistentAriaRelatedElement.js
@@ -19,9 +19,9 @@ goog.require('axs.constants.Severity');
 // TODO(RickSBrown): Consider expanding this beyond ARIA? e.g. 'for' on label.
 
 /**
- * @type {axs.AuditRule.Spec}
+ * 'ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM'
  */
-axs.AuditRule.specs.nonExistentAriaRelatedElement = {
+axs.AuditRules.addRule({
     name: 'nonExistentAriaRelatedElement',
     heading: 'ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM',
     url: '',
@@ -52,4 +52,4 @@ axs.AuditRule.specs.nonExistentAriaRelatedElement = {
         return false;
     },
     code: 'AX_ARIA_02'
-};
+});

--- a/src/audits/PageWithoutTitle.js
+++ b/src/audits/PageWithoutTitle.js
@@ -15,10 +15,7 @@
 goog.require('axs.AuditRule');
 goog.require('axs.constants.Severity');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.pageWithoutTitle = {
+axs.AuditRules.addRule({
     name: 'pageWithoutTitle',
     heading: 'The web page should have a title that describes topic or purpose',
     url: '',
@@ -36,4 +33,4 @@ axs.AuditRule.specs.pageWithoutTitle = {
         return !title.textContent;
     },
     code: 'AX_TITLE_01'
-};
+});

--- a/src/audits/RequiredAriaAttributeMissing.js
+++ b/src/audits/RequiredAriaAttributeMissing.js
@@ -18,10 +18,7 @@ goog.require('axs.browserUtils');
 goog.require('axs.constants');
 goog.require('axs.properties');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.requiredAriaAttributeMissing = {
+axs.AuditRules.addRule({
     name: 'requiredAriaAttributeMissing',
     heading: 'Elements with ARIA roles must have all required attributes for that role',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_03--elements-with-aria-roles-must-have-all-required-attributes-for-that-role',
@@ -51,4 +48,4 @@ axs.AuditRule.specs.requiredAriaAttributeMissing = {
         }
     },
     code: 'AX_ARIA_03'
-};
+});

--- a/src/audits/RequiredOwnedAriaRoleMissing.js
+++ b/src/audits/RequiredOwnedAriaRoleMissing.js
@@ -16,15 +16,62 @@ goog.require('axs.AuditRule');
 goog.require('axs.AuditRules');
 goog.require('axs.constants');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.requiredOwnedAriaRoleMissing = {
-    name: 'requiredOwnedAriaRoleMissing',
-    heading: 'Elements with ARIA roles must ensure required owned elements are present',
-    url: '',
-    severity: axs.constants.Severity.SEVERE,
-    _getRequired: function(element) {
+(function(){
+    /**
+     * @type {axs.AuditRule.Spec}
+     */
+    var spec = {
+        name: 'requiredOwnedAriaRoleMissing',
+        heading: 'Elements with ARIA roles must ensure required owned elements are present',
+        url: '',
+        severity: axs.constants.Severity.SEVERE,
+        relevantElementMatcher: function(element) {
+            if (!axs.browserUtils.matchSelector(element, '[role]'))
+                return false;
+            var required = getRequired(element);
+            return required.length > 0;
+
+        },
+        test: function(element) {
+            /*
+             * Checks that this element contains everything it "must contain".
+             */
+            var busy = element.getAttribute('aria-busy');
+            if (busy === 'true')  // In future this will lower the severity of the warning instead
+                return false;  // https://github.com/GoogleChrome/accessibility-developer-tools/issues/101
+
+            var required = getRequired(element);
+            for (var i = required.length - 1; i >= 0; i--) {
+                 var descendants = axs.utils.findDescendantsWithRole(element, required[i]);
+                 if (descendants && descendants.length) {  // if we found at least one descendant with a required role
+                     return false;
+                 }
+             }
+             // if we get to this point our element has 'required owned elements' but it does not own them implicitly in the DOM
+             var ownedElements = axs.utils.getIdReferents('aria-owns', element);
+             for (var i = ownedElements.length - 1; i >= 0; i--) {
+                 var ownedElement = ownedElements[i];
+                 var ownedElementRole = axs.utils.getRoles(ownedElement, true);
+                 if (ownedElementRole && ownedElementRole.roles.length) {
+                     ownedElementRole = ownedElementRole.roles[0];
+                     for (var j = required.length - 1; j >= 0; j--) {
+                        if (ownedElementRole.name === required[j]) {  // if this explicitly owned element has a required role
+                            return false;
+                        }
+                    }
+                 }
+             }
+             return true;  // if we made it here then we did not find the required owned elements in the DOM
+        },
+        code: 'AX_ARIA_08'
+    };
+
+    /**
+     * Get a list of the roles this element must contain, if any, based on its ARIA role.
+     * @param {Element} element A DOM element.
+     * @return {Array.<string>} The roles this element must contain.
+     */
+    function getRequired(element) {
         var elementRole = axs.utils.getRoles(element);
         if (!elementRole || !elementRole.roles.length)
             return [];
@@ -32,44 +79,7 @@ axs.AuditRule.specs.requiredOwnedAriaRoleMissing = {
         if (!elementRole.valid)
             return [];
         return elementRole.details['mustcontain'] || [];
-    },
-    relevantElementMatcher: function(element) {
-        if (!axs.browserUtils.matchSelector(element, '[role]'))
-            return false;
-        var required = axs.AuditRule.specs.requiredOwnedAriaRoleMissing._getRequired(element);
-        return required.length > 0;
-        
-    },
-    test: function(element) {
-        /*
-         * Checks that this element contains everything it "must contain".
-         */
-        var busy = element.getAttribute('aria-busy');
-        if (busy === 'true')  // In future this will lower the severity of the warning instead
-            return false;  // https://github.com/GoogleChrome/accessibility-developer-tools/issues/101
+    }
+    axs.AuditRules.addRule(spec);
+})();
 
-        var required = axs.AuditRule.specs.requiredOwnedAriaRoleMissing._getRequired(element);
-        for (var i = required.length - 1; i >= 0; i--) {
-             var descendants = axs.utils.findDescendantsWithRole(element, required[i]);
-             if (descendants && descendants.length) {  // if we found at least one descendant with a required role
-                 return false;
-             }
-         }
-         // if we get to this point our element has 'required owned elements' but it does not own them implicitly in the DOM
-         var ownedElements = axs.utils.getIdReferents('aria-owns', element);
-         for (var i = ownedElements.length - 1; i >= 0; i--) {
-             var ownedElement = ownedElements[i];
-             var ownedElementRole = axs.utils.getRoles(ownedElement, true);
-             if (ownedElementRole && ownedElementRole.roles.length) {
-                 ownedElementRole = ownedElementRole.roles[0];
-                 for (var j = required.length - 1; j >= 0; j--) {
-                    if (ownedElementRole.name === required[j]) {  // if this explicitly owned element has a required role
-                        return false;
-                    }
-                }
-             }
-         }
-         return true;  // if we made it here then we did not find the required owned elements in the DOM
-    },
-    code: 'AX_ARIA_08'
-};

--- a/src/audits/TabIndexGreaterThanZero.js
+++ b/src/audits/TabIndexGreaterThanZero.js
@@ -15,11 +15,7 @@
 goog.require('axs.AuditRule');
 goog.require('axs.constants.Severity');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-
-axs.AuditRule.specs.tabIndexGreaterThanZero = {
+axs.AuditRules.addRule({
     name: "tabIndexGreaterThanZero",
     heading: "Avoid positive integer values for tabIndex",
     url: "https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_03--avoid-positive-integer-values-for-tabindex",
@@ -33,4 +29,4 @@ axs.AuditRule.specs.tabIndexGreaterThanZero = {
         return true;
     },
     code: 'AX_FOCUS_03'
-};
+});

--- a/src/audits/UnfocusableElementsWithOnClick.js
+++ b/src/audits/UnfocusableElementsWithOnClick.js
@@ -17,10 +17,7 @@ goog.require('axs.AuditRules');
 goog.require('axs.constants.Severity');
 goog.require('axs.utils');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.unfocusableElementsWithOnClick = {
+axs.AuditRules.addRule({
     name: 'unfocusableElementsWithOnClick',
     heading: 'Elements with onclick handlers must be focusable',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_02--elements-with-onclick-handlers-must-be-focusable',
@@ -46,4 +43,4 @@ axs.AuditRule.specs.unfocusableElementsWithOnClick = {
                !element.disabled;
     },
     code: 'AX_FOCUS_02'
-};
+});

--- a/src/audits/UnsupportedAriaAttribute.js
+++ b/src/audits/UnsupportedAriaAttribute.js
@@ -31,7 +31,7 @@ goog.require('axs.constants');
      *
      * @type {axs.AuditRule.Spec}
      */
-    axs.AuditRule.specs.unsupportedAriaAttribute = {
+    var unsupportedAriaAttribute = {
         name: 'unsupportedAriaAttribute',
         heading: 'This element has an unsupported ARIA attribute',
         url: '',
@@ -65,4 +65,5 @@ goog.require('axs.constants');
         },
         code: 'AX_ARIA_10'
     };
+    axs.AuditRules.addRule(unsupportedAriaAttribute);
 })();

--- a/src/audits/VideoWithoutCaptions.js
+++ b/src/audits/VideoWithoutCaptions.js
@@ -15,10 +15,7 @@
 goog.require('axs.AuditRules');
 goog.require('axs.constants.Severity');
 
-/**
- * @type {axs.AuditRule.Spec}
- */
-axs.AuditRule.specs.videoWithoutCaptions = {
+axs.AuditRules.addRule({
     name: 'videoWithoutCaptions',
     heading: 'Video elements should use <track> elements to provide captions',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_video_01--video-elements-should-use-track-elements-to-provide-captions',
@@ -31,4 +28,4 @@ axs.AuditRule.specs.videoWithoutCaptions = {
         return !captions.length;
     },
     code: 'AX_VIDEO_01'
-};
+});

--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -132,7 +132,7 @@ axs.AuditConfiguration.prototype = {
         if (!(auditRuleName in this.rules_))
             return null;
         if (!('severity' in this.rules_[auditRuleName]))
-            return null
+            return null;
         return this.rules_[auditRuleName].severity;
     },
 
@@ -180,14 +180,12 @@ axs.Audit.getRulesCannotRun = function(opt_configuration) {
     if(opt_configuration.withConsoleApi) {
         return [];
     }
-    return Object.keys(axs.AuditRule.specs)
-        .filter(function(key) {
-            return axs.AuditRules.getRule(key).requiresConsoleAPI;
-        })
-        .map(function(key) {
-            return axs.AuditRules.getRule(key).code;
+    return axs.AuditRules.getRules().filter(function(rule) {
+            return rule.requiresConsoleAPI;
+        }).map(function(rule) {
+            return rule.code;
         });
-}
+};
 
 /**
  * Runs an audit with all of the audit rules.
@@ -209,7 +207,7 @@ axs.Audit.run = function(opt_configuration) {
         configuration.auditRulesToRun.length > 0) {
         auditRules = configuration.auditRulesToRun;
     } else
-        auditRules = Object.keys(axs.AuditRule.specs);
+        auditRules = axs.AuditRules.getRules(true);
 
     if (configuration.auditRulesToIgnore) {
         for (var i = 0; i < configuration.auditRulesToIgnore.length; i++) {
@@ -319,15 +317,15 @@ goog.exportSymbol('axs.Audit.createReport', axs.Audit.createReport);
  */
 axs.Audit.accessibilityErrorMessage = function(result) {
     if (result.rule.severity == axs.constants.Severity.SEVERE)
-        var message = 'Error: '
+        var message = 'Error: ';
     else
-        var message = 'Warning: '
+        var message = 'Warning: ';
     message += result.rule.code + ' (' + result.rule.heading +
         ') failed on the following ' +
         (result.elements.length == 1 ? 'element' : 'elements');
 
     if (result.elements.length == 1)
-        message += ':'
+        message += ':';
     else {
         message += ' (1 - ' + Math.min(5, result.elements.length) +
                    ' of ' + result.elements.length + '):';

--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -243,4 +243,4 @@ axs.AuditRule.prototype.run = function(options) {
     return results;
 };
 
-axs.AuditRule.specs = {};
+// axs.AuditRule.specs = {};

--- a/src/js/AuditRules.js
+++ b/src/js/AuditRules.js
@@ -31,8 +31,10 @@ goog.provide('axs.AuditRules');
         // create the auditRule before checking props as we can expect the constructor to perform the
         // first layer of sanity checking.
         var auditRule = new axs.AuditRule(spec);
-        if (auditRule.code in auditRulesByCode || auditRule.name in auditRulesByName)
-            throw new Error('Can not add audit rule with same name or code: "' + auditRule.code + '"/"' + auditRule.name + '"');
+        if (auditRule.code in auditRulesByCode)
+            throw new Error('Can not add audit rule with same code: "' + auditRule.code + '"');
+        if (auditRule.name in auditRulesByName)
+            throw new Error('Can not add audit rule with same name: "' + auditRule.name + '"');
         auditRulesByName[auditRule.name] = auditRulesByCode[auditRule.code] = auditRule;
     };
 
@@ -47,12 +49,12 @@ goog.provide('axs.AuditRules');
 
     /**
      * Gets all registered audit rules.
-     * @param {boolean=} namesOnly If true then the result will contain only the rule names.
+     * @param {boolean=} opt_namesOnly If true then the result will contain only the rule names.
      * @return {Array.<axs.AuditRule>|Array.<string>}
      */
-    axs.AuditRules.getRules = function(namesOnly) {
+    axs.AuditRules.getRules = function(opt_namesOnly) {
         var ruleNames = Object.keys(auditRulesByName);
-        if(namesOnly)
+        if(opt_namesOnly)
             return ruleNames;
         return ruleNames.map(function(name) {
             return this.getRule(name);

--- a/test/index.html
+++ b/test/index.html
@@ -47,6 +47,7 @@
     <script src="./js/browser-utils-test.js"></script>
     <script src="./js/audit-configuration-test.js"></script>
     <script src="./js/audit-rule-test.js"></script>
+	<script src="./js/audit-rules-test.js"></script>
     <script src="./audits/aria-on-reserved-element-test.js"></script>
     <script src="./audits/aria-owns-descendant-test.js"></script>
     <script src="./audits/aria-role-not-scoped-test.js"></script>

--- a/test/js/audit-configuration-test.js
+++ b/test/js/audit-configuration-test.js
@@ -1,11 +1,10 @@
 module("AuditConfiguration", {
   setup: function() {
-    this.auditRules_ = [];
-    for (var auditRuleName in axs.AuditRule.specs) {
-      var spec = axs.AuditRule.specs[auditRuleName];
-      if (!spec.opt_requiresConsoleAPI)
-        this.auditRules_.push(auditRuleName);
-    }
+    this.auditRules_ = axs.AuditRules.getRules().filter(function(auditRule) {
+        return !auditRule.requiresConsoleAPI;
+    }).map(function(auditRule) {
+        return auditRule.name;
+    });
   }
 });
 
@@ -42,7 +41,7 @@ test("Configure severity of an audit rule", function() {
       continue;
     var result = results[i];
     equal(result.rule.severity, axs.constants.Severity.WARNING);
-    notEqual(result.rule.severity, axs.AuditRule.specs['badAriaRole'].severity);
+    notEqual(result.rule.severity, axs.AuditRules.getRule('badAriaRole').severity);
     return;
   }
 });

--- a/test/js/audit-rules-test.js
+++ b/test/js/audit-rules-test.js
@@ -1,0 +1,97 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(){
+
+    module("axs.AuditRules.getRules");
+
+    function buildDummySpec() {
+        var dummySpec = {
+            name: 'dummySpec',
+            heading: 'This is a dummy spec',
+            url: '',
+            severity: axs.constants.Severity.WARNING,
+            relevantElementMatcher: function() {
+                throw new Error('This should never be called');
+            },
+            test: function() {
+                throw new Error('This should never be called');
+            },
+            code: 'AX_DUMMY_01'
+        };
+        return dummySpec;
+    }
+    
+
+    test("Get all registered rules", function () {
+        var rules = axs.AuditRules.getRules();
+        notEqual(rules.length, 0, 'Nothing to test!');
+        for (var i = 0; i < rules.length; i++) {
+            ok(rules[i] instanceof axs.AuditRule);
+        }
+    });
+
+    test("Get all registered rule names", function () {
+        var rules = axs.AuditRules.getRules();
+        notEqual(rules.length, 0, 'Nothing to test!');
+        var names = axs.AuditRules.getRules(true);
+        equal(rules.length, names.length, 'A name for every rule and a rule for every name!');
+        for (var i = 0; i < rules.length; i++) {
+            equal(rules[i].name, names[i]);
+        }
+    });
+
+    module("axs.AuditRules.getRule");
+
+    test("Attempt to register a rule with a duplicate name", function () {
+        var rules = axs.AuditRules.getRules();
+        notEqual(rules.length, 0, 'Nothing to test!');
+        for (var i = 0; i < rules.length; i++) {
+            var rule = axs.AuditRules.getRule(rules[0].name);
+            strictEqual(rules[0], rule);
+        }
+    });
+
+    module("axs.AuditRules.addRule");
+
+    test("Attempt to add a rule with a duplicate name", function () {
+        var rules = axs.AuditRules.getRules();
+        var ruleCount = rules.length;
+        notEqual(ruleCount, 0, 'Nothing to test!');
+        var ruleBefore = axs.AuditRules.getRule(rules[0].name);
+        var spec = buildDummySpec();
+        spec.name = ruleBefore.name;
+        raises(function() {
+            axs.AuditRules.addRule(spec);
+        }, "An error should be thrown when trying to add a rule with duplicate name.");
+        var ruleAfter = axs.AuditRules.getRule(ruleBefore.name);
+        strictEqual(ruleBefore, ruleAfter, 'addRule should not have added a spec with a duplicate name');
+        strictEqual(ruleCount, axs.AuditRules.getRules().length, 'rules collection should not have changed');
+    });
+
+    test("Attempt to add a rule with a duplicate code", function () {
+        var rules = axs.AuditRules.getRules();
+        var ruleCount = rules.length;
+        notEqual(ruleCount, 0, 'Nothing to test!');
+        var ruleBefore = axs.AuditRules.getRule(rules[0].name);
+        var spec = buildDummySpec();
+        spec.code = ruleBefore.code;
+        raises(function() {
+            axs.AuditRules.addRule(spec);
+        }, "An error should be thrown when trying to add a rule with duplicate code.");
+        var ruleAfter = axs.AuditRules.getRule(ruleBefore.name);
+        strictEqual(ruleBefore, ruleAfter, 'addRule should not have added a spec with a duplicate code');
+        strictEqual(ruleCount, axs.AuditRules.getRules().length, 'rules collection should not have changed');
+    });
+})();


### PR DESCRIPTION
Prevent audit rules being registered with duplicate name or code (Closes issue #133).
Added new method`axs.AuditRules.addRule` to register rules instead of adding them to `axs.AuditRule.specs`.
Removed `axs.AuditRule.specs` - this breaks backwards compatibility - the extension will need to be updated.
Removed public `axs.AuditRules.rules` because:
    a) it was never used;
    b) there is a getter method to access these.
Added new method `axs.AuditRules.getRules` to replace the functionality of `axs.AuditRule.specs` and axs.AuditRules.rules.

Fixed duplicate AX_ARIA_04
Fixed duplicate AX_TITLE_01