### PR TITLE
+ Selenium WebDriver example (scala)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,17 @@ The Accessibility Developer Tools project includes a command line runner for the
 
 The runner will load the specified file or URL in a headless browser, inject axs_testing.js, run the audit and output the report text.
 
-### Run from Selenium WebDriver (Scala):
-     val driver = org.openqa.selenium.firefox.FirefoxDriver //use whatever driver you want
+### Run audit from Selenium WebDriver (Scala):
+     val driver = org.openqa.selenium.firefox.FirefoxDriver //use driver of your choice
      val jse = driver.asInstanceOf[JavascriptExecutor]
      jse.executeScript(scala.io.Source.fromURL("https://raw.githubusercontent.com/GoogleChrome/" +
        "accessibility-developer-tools/stable/dist/js/axs_testing.js").mkString)
+     val report = js.executeScript("var results = axs.Audit.run();return axs.Audit.createReport(results);")
+     println(report)
     
-### Run from Selenium WebDriver (Scala)(with caching):
+### Run audit from Selenium WebDriver (Scala)(with caching):
      val cache = collection.mutable.Map[String, String]()
-     val driver = org.openqa.selenium.firefox.FirefoxDriver //use whatever driver you want
+     val driver = org.openqa.selenium.firefox.FirefoxDriver //use driver of your choice
      val jse = driver.asInstanceOf[JavascriptExecutor]
      def getUrlSource(arg: String): String = cache get arg match {
         case Some(result) => result
@@ -97,8 +99,11 @@ The runner will load the specified file or URL in a headless browser, inject axs
      val jse = driver.asInstanceOf[JavascriptExecutor]
      jse.executeScript(getUrlSource("https://raw.githubusercontent.com/GoogleChrome/" +
        "accessibility-developer-tools/stable/dist/js/axs_testing.js"))
+     val report = js.executeScript("var results = axs.Audit.run();return axs.Audit.createReport(results);")
+     println(report)
     
-
+If println() outputs nothing, check if you need to set DesiredCapabilities for your WebDriver (such as loggingPrefs):
+https://code.google.com/p/selenium/wiki/DesiredCapabilities
 
 ## Using the results
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ The Accessibility Developer Tools project includes a command line runner for the
 
 The runner will load the specified file or URL in a headless browser, inject axs_testing.js, run the audit and output the report text.
 
+### Run from Selenium WebDriver (Scala):
+     val driver = org.openqa.selenium.firefox.FirefoxDriver //use whatever driver you want
+     val jse = driver.asInstanceOf[JavascriptExecutor]
+     jse.executeScript(scala.io.Source.fromURL("https://raw.githubusercontent.com/GoogleChrome/" +
+       "accessibility-developer-tools/stable/dist/js/axs_testing.js").mkString)
+    
+### Run from Selenium WebDriver (Scala)(with caching):
+     val cache = collection.mutable.Map[String, String]()
+     val driver = org.openqa.selenium.firefox.FirefoxDriver //use whatever driver you want
+     val jse = driver.asInstanceOf[JavascriptExecutor]
+     def getUrlSource(arg: String): String = cache get arg match {
+        case Some(result) => result
+        case None =>
+          val result: String = scala.io.Source.fromURL(arg).mkString
+          cache(arg) = result
+          result
+      }
+     val driver = YourChoiceOfDriver
+     val jse = driver.asInstanceOf[JavascriptExecutor]
+     jse.executeScript(getUrlSource("https://raw.githubusercontent.com/GoogleChrome/" +
+       "accessibility-developer-tools/stable/dist/js/axs_testing.js"))
+    
+
+
 ## Using the results
 
 ### Interpreting the result

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ The runner will load the specified file or URL in a headless browser, inject axs
           cache(arg) = result
           result
       }
-     val driver = YourChoiceOfDriver
-     val jse = driver.asInstanceOf[JavascriptExecutor]
      jse.executeScript(getUrlSource("https://raw.githubusercontent.com/GoogleChrome/" +
        "accessibility-developer-tools/stable/dist/js/axs_testing.js"))
      val report = js.executeScript("var results = axs.Audit.run();return axs.Audit.createReport(results);")


### PR DESCRIPTION
Wrote code example on how to run the audit javascript via Selenium WebDriver JavascriptExecutor.
+ Some bits about caching for common sense.