### PR TITLE
updates links to Audit Rules wiki to use the new anchors

### DIFF
--- a/src/audits/AriaOnReservedElement.js
+++ b/src/audits/AriaOnReservedElement.js
@@ -22,7 +22,7 @@ goog.require('axs.properties');
 axs.AuditRules.addRule({
     name: 'ariaOnReservedElement',
     heading: 'This element does not support ARIA roles, states and properties',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_12--this-element-does-not-support-aria-roles-states-and-properties',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_12',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return !axs.properties.canTakeAriaAttributes(element);

--- a/src/audits/AriaOwnsDescendant.js
+++ b/src/audits/AriaOwnsDescendant.js
@@ -27,7 +27,7 @@ axs.AuditRules.addRule({
     // Also: other "bad hierarchy" tests - e.g. active-descendant owning a non-descendant...
     name: 'ariaOwnsDescendant',
     heading: 'aria-owns should not be used if ownership is implicit in the DOM',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_06--aria-owns-should-not-be-used-if-ownership-is-implicit-in-the-dom',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_06',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, '[aria-owns]');

--- a/src/audits/AriaRoleNotScoped.js
+++ b/src/audits/AriaRoleNotScoped.js
@@ -25,7 +25,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'ariaRoleNotScoped',
     heading: 'Elements with ARIA roles must be in the correct scope',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_09--elements-with-aria-roles-must-be-in-the-correct-scope',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_09',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, '[role]');

--- a/src/audits/AudioWithoutControls.js
+++ b/src/audits/AudioWithoutControls.js
@@ -22,7 +22,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: 'audioWithoutControls',
     heading: 'Audio elements should have controls',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_audio_01--audio-elements-should-have-controls',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_audio_01',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, 'audio[autoplay]');

--- a/src/audits/BadAriaAttribute.js
+++ b/src/audits/BadAriaAttribute.js
@@ -33,7 +33,7 @@ goog.require('axs.constants');
     var badAriaAttribute = {
         name: 'badAriaAttribute',
         heading: 'This element has an invalid ARIA attribute',
-        url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_11--this-element-has-an-invalid-aria-attribute',
+        url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_11',
         severity: axs.constants.Severity.WARNING,
         relevantElementMatcher: function(element) {
             var attributes = element.attributes;

--- a/src/audits/BadAriaAttributeValue.js
+++ b/src/audits/BadAriaAttributeValue.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'badAriaAttributeValue',
     heading: 'ARIA state and property values must be valid',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_04--aria-state-and-property-values-must-be-valid',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         var selector = axs.utils.getSelectorForAriaProperties(axs.constants.ARIA_PROPERTIES);

--- a/src/audits/BadAriaRole.js
+++ b/src/audits/BadAriaRole.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'badAriaRole',
     heading: 'Elements with ARIA roles must use a valid, non-abstract ARIA role',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_01--elements-with-aria-roles-must-use-a-valid-non-abstract-aria-role',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_01',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, '[role]');

--- a/src/audits/ControlsWithoutLabel.js
+++ b/src/audits/ControlsWithoutLabel.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'controlsWithoutLabel',
     heading: 'Controls and media elements should have labels',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_text_01--controls-and-media-elements-should-have-labels',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_01',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         var controlsSelector = ['input:not([type="hidden"]):not([disabled])',

--- a/src/audits/DuplicateId.js
+++ b/src/audits/DuplicateId.js
@@ -22,7 +22,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: 'duplicateId',
     heading: 'An element\'s ID must be unique in the DOM',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_html_02--an-elements-id-must-be-unique-in-the-dom',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_02',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, '[id]');

--- a/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
+++ b/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'focusableElementNotVisibleAndNotAriaHidden',
     heading: 'These elements are focusable but either invisible or obscured by another element',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_01--these-elements-are-focusable-but-either-invisible-or-obscured-by-another-element',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_01',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         var isFocusable = axs.browserUtils.matchSelector(

--- a/src/audits/HumanLangMissing.js
+++ b/src/audits/HumanLangMissing.js
@@ -18,7 +18,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: 'humanLangMissing',
     heading: 'The web page should have the content\'s human language indicated in the markup',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_html_01--the-web-page-should-have-the-contents-human-language-indicated-in-the-markup',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_01',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return element instanceof element.ownerDocument.defaultView.HTMLHtmlElement;

--- a/src/audits/ImageWithoutAltText.js
+++ b/src/audits/ImageWithoutAltText.js
@@ -20,7 +20,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'imagesWithoutAltText',
     heading: 'Images should have an alt attribute',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_text_02--images-should-have-an-alt-attribute-unless-they-have-an-aria-role-of-presentation',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_02',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, 'img') &&

--- a/src/audits/LinkWithUnclearPurpose.js
+++ b/src/audits/LinkWithUnclearPurpose.js
@@ -22,7 +22,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: 'linkWithUnclearPurpose',
     heading: 'The purpose of each link should be clear from the link text',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_text_04--the-purpose-of-each-link-should-be-clear-from-the-link-text',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_04',
     severity: axs.constants.Severity.WARNING,
     /**
      * @param {Element} element

--- a/src/audits/LowContrast.js
+++ b/src/audits/LowContrast.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'lowContrastElements',
     heading: 'Text elements should have a reasonable contrast ratio',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_color_01--text-elements-should-have-a-reasonable-contrast-ratio',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_color_01',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return axs.properties.hasDirectTextDescendant(element);

--- a/src/audits/MainRoleOnInappropriateElement.js
+++ b/src/audits/MainRoleOnInappropriateElement.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'mainRoleOnInappropriateElement',
     heading: 'role=main should only appear on significant elements',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_05--rolemain-should-only-appear-on-significant-elements',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_05',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, '[role~=main]');

--- a/src/audits/MeaningfulBackgroundImage.js
+++ b/src/audits/MeaningfulBackgroundImage.js
@@ -26,7 +26,7 @@ axs.AuditRules.addRule({
         return !axs.utils.isElementOrAncestorHidden(element);
     },
     heading: 'Meaningful images should not be used in element backgrounds',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_image_01--meaningful-images-should-not-be-used-in-element-backgrounds',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_image_01',
     test: function(el) {
         if (el.textContent && el.textContent.length > 0) {
           return false;

--- a/src/audits/MultipleAriaOwners.js
+++ b/src/audits/MultipleAriaOwners.js
@@ -23,7 +23,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'multipleAriaOwners',
     heading: 'An element\'s ID must not be present in more that one aria-owns attribute at any time',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_07--an-element-can-have-only-one-explicit-aria-owner',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_07',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         /*

--- a/src/audits/NonExistentAriaRelatedElement.js
+++ b/src/audits/NonExistentAriaRelatedElement.js
@@ -25,7 +25,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'nonExistentAriaRelatedElement',
     heading: 'ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_02--aria-labelledby-attributes-should-refer-to-an-element-which-exists-in-the-dom',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_02',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         var idrefTypes = ['idref', 'idref_list'];

--- a/src/audits/PageWithoutTitle.js
+++ b/src/audits/PageWithoutTitle.js
@@ -18,7 +18,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: 'pageWithoutTitle',
     heading: 'The web page should have a title that describes topic or purpose',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_title_01--the-web-page-should-have-a-title-that-describes-topic-or-purpose',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_title_01',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return element.tagName.toLowerCase() == "html";

--- a/src/audits/RequiredAriaAttributeMissing.js
+++ b/src/audits/RequiredAriaAttributeMissing.js
@@ -21,7 +21,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'requiredAriaAttributeMissing',
     heading: 'Elements with ARIA roles must have all required attributes for that role',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_03--elements-with-aria-roles-must-have-all-required-attributes-for-that-role',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_03',
     severity: axs.constants.Severity.SEVERE,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, '[role]');

--- a/src/audits/RequiredOwnedAriaRoleMissing.js
+++ b/src/audits/RequiredOwnedAriaRoleMissing.js
@@ -24,7 +24,7 @@ goog.require('axs.utils');
     var spec = {
         name: 'requiredOwnedAriaRoleMissing',
         heading: 'Elements with ARIA roles must ensure required owned elements are present',
-        url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_08--elements-with-aria-roles-must-ensure-required-owned-elements-are-present',
+        url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_08',
         severity: axs.constants.Severity.SEVERE,
         relevantElementMatcher: function(element) {
             if (!axs.browserUtils.matchSelector(element, '[role]'))
@@ -83,4 +83,3 @@ goog.require('axs.utils');
     }
     axs.AuditRules.addRule(spec);
 })();
-

--- a/src/audits/TabIndexGreaterThanZero.js
+++ b/src/audits/TabIndexGreaterThanZero.js
@@ -19,7 +19,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: "tabIndexGreaterThanZero",
     heading: "Avoid positive integer values for tabIndex",
-    url: "https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_03--avoid-positive-integer-values-for-tabindex",
+    url: "https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_03",
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
       var selector = "[tabindex]";

--- a/src/audits/UnfocusableElementsWithOnClick.js
+++ b/src/audits/UnfocusableElementsWithOnClick.js
@@ -19,7 +19,7 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'unfocusableElementsWithOnClick',
     heading: 'Elements with onclick handlers must be focusable',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_focus_02--elements-with-onclick-handlers-must-be-focusable',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_02',
     severity: axs.constants.Severity.WARNING,
     opt_requiresConsoleAPI: true,
     relevantElementMatcher: function(element) {

--- a/src/audits/UnsupportedAriaAttribute.js
+++ b/src/audits/UnsupportedAriaAttribute.js
@@ -35,7 +35,7 @@ goog.require('axs.utils');
     var unsupportedAriaAttribute = {
         name: 'unsupportedAriaAttribute',
         heading: 'This element has an unsupported ARIA attribute',
-        url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_aria_10--this-element-has-an-unsupported-aria-attribute',
+        url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_10',
         severity: axs.constants.Severity.SEVERE,
         relevantElementMatcher: function(element) {
             return axs.browserUtils.matchSelector(element, selector);

--- a/src/audits/VideoWithoutCaptions.js
+++ b/src/audits/VideoWithoutCaptions.js
@@ -19,7 +19,7 @@ goog.require('axs.constants.Severity');
 axs.AuditRules.addRule({
     name: 'videoWithoutCaptions',
     heading: 'Video elements should use <track> elements to provide captions',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#-ax_video_01--video-elements-should-use-track-elements-to-provide-captions',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_video_01',
     severity: axs.constants.Severity.WARNING,
     relevantElementMatcher: function(element) {
         return axs.browserUtils.matchSelector(element, 'video');


### PR DESCRIPTION
Hello, I recently updated the [Audit Rules](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules) wiki page to simplify the anchors on every rule, so they are easier to link from other projects ([see an example](https://github.com/accesslint/access_lint)).

I think that using just the audit rule ID, for example `#ax_aria_12` is much clearer than using a longer English string like `#-ax_aria_12--this-element-does-not-support-aria-roles-states-and-properties`.

The description text, "this element does not support aria roles states and properties" is much more prone to change in the future than the ID "ax_aria_12". Also, the anchors included a whitespace at the beginning that made them look a bit weird.

This PR changes the links to every audit rule to use the new anchors.

