### PR TITLE
Release automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ extension/Handlebar.js
 upload.py
 gen/
 node_modules/
+.tmp/

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### Enhancements:
+* Rework findTextAlternatives not to return non-exposed text alternatives.
+* Add Bower config (#157)
+
+### Bug fixes:
+* Check for any text alternatives when assessing unlabeled images (#154).
+
 ## 2.7.0 - 2015-05-15
 
 ### New rules

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,59 @@
+## 2.7.0 - 2015-05-15
+
+### New rules
+* This element does not support ARIA roles, states and properties (`src/audits/AriaOnReservedElement.js`)
+* aria-owns should not be used if ownership is implicit in the DOM (`src/audits/AriaOwnsDescendant.js`)
+* Elements with ARIA roles must be in the correct scope (`src/audits/AriaRoleNotScoped.js`)
+* An element's ID must be unique in the DOM (`src/audits/DuplicateId.js`)
+* The web page should have the content's human language indicated in the markup (`src/audits/HumanLangMissing.js`)
+* An element's ID must not be present in more that one aria-owns attribute at any time (`src/audits/MultipleAriaOwners.js`)
+* ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM (`src/audits/NonExistentAriaRelatedElement.js` - previously `src/audits/NonExistentAriaLabeledBy.js`)
+* Elements with ARIA roles must ensure required owned elements are present (`src/audits/RequiredOwnedAriaRoleMissing.js`)
+* Avoid positive integer values for tabIndex (`src/audits/TabIndexGreaterThanZero.js`)
+* This element has an unsupported ARIA attribute (`src/audits/UnsupportedAriaAttribute.js`)
+
+### Enhancements:
+* Add configurable blacklist phrases and stop words to LinkWithUnclearPurpose (#99)
+* Detect and warn if we reuse the same code for more than one rule. (#133)
+* Force focus before testing visibility on focusable elements. (#65)
+* Use getDistributedNodes to get nodes distributed into shadowRoots (#128)
+* Add section to Audit Rules page for HumanLangMissing and link to it from rule (#119)
+* Reference "applied role" in axs.utils.getRoles enhancement (#130)
+* Add warning that AX_FOCUS_02 is not available from axs.Audit.run() (#85)
+
+### Bug fixes:
+* Incorrect use of nth-of-type against className in utils.getQuerySelectorText (#87)
+* AX_TEXT_01 Accessibility Audit test should probably ignore role=presentation elements (#97)
+* Fix path to audit rules in phantomjs runner (#108)
+* Label audit should fail if form fields lack a label, even with placeholder text (#81)
+* False positives for controls without labels with role=presentation (#23)
+* Fix "valid" flag on return value of axs.utils.getRoles (#131)
+
+Note: this version number is somewhat arbitrary - just bringing it vaguely in line with [the extension](https://github.com/GoogleChrome/accessibility-developer-tools-extension) since that's where the library originated - but will use semver for version bumps going forward from here.
+
+## 0.0.5 - 2014-02-04
+
+### Enhancements:
+* overlapping elements detection code made more sophisticated
+* axs.properties.getFocusProperties() returns more information about visibility
+* new axs.properties.hasDirectTextDescendant() method with more sophisticated detection of text content
+
+### Bug fixes:
+* FocusableElementNotVisibleAndNotAriaHidden audit passes on elements which are brought onscreen on focus
+* UnfocusableElementsWithOnclick checks for element.disabled
+* Fix infinite loop when getting descendant text content of a label containing an input
+* Detect elements which are out of scroll area of any parent element, not just the document scroll area
+* findTextAlternatives doesn't throw TypeError if used on a HTMLSelectElement
+
+## 0.0.4 - 2013-10-03
+
+### Enhancements:
+
+* axs.AuditRule.run() has a new signature: it now takes an options object. Please see method documentation for details.
+* Audit Rule severity can be overridden (per Audit Rule) in AuditConfig.
+
+### Bug fixes:
+
+* axs.utils.isLowContrast() now rounds to the nearest 0.1 before checking (so `#777` is now a passing value)
+* MainRoleOnInappropriateElement was always failing due to accessible name calculation taking the main role into account and not descending into content (now just gets descendant content directly)
+* UnfocusableElementsWithOnClick had a dangling if-statement causing very noisy false positives

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,63 +1,188 @@
-'use strict';
+var request = require('superagent');
 
 module.exports = function(grunt) {
-  grunt.initConfig({
-    'git-describe': {
-      options: {
+  'use strict';
 
-      },
-      'run': {}
-    },
+  require('load-grunt-tasks')(grunt);
+
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    changelog: 'CHANGELOG.md',
+
+    'gh-release': {},
+
     closurecompiler: {
       minify: {
         requiresConfig: 'git-revision',
         files: {
-          "gen/axs_testing.js": [
-              "./lib/closure-library/closure/goog/base.js",
-              "./src/js/axs.js",
-              "./src/js/BrowserUtils.js",
-              "./src/js/Constants.js",
-              "./src/js/AccessibilityUtils.js",
-              "./src/js/Properties.js",
-              "./src/js/AuditRule.js",
-              "./src/js/AuditRules.js",
-              "./src/js/AuditResults.js",
-              "./src/js/Audit.js",
-              "./src/audits/*"
+          '.tmp/build/axs_testing.js': [
+              './lib/closure-library/closure/goog/base.js',
+              './src/js/axs.js',
+              './src/js/BrowserUtils.js',
+              './src/js/Constants.js',
+              './src/js/AccessibilityUtils.js',
+              './src/js/Properties.js',
+              './src/js/AuditRule.js',
+              './src/js/AuditRules.js',
+              './src/js/AuditResults.js',
+              './src/js/Audit.js',
+              './src/audits/*'
           ]
         },
         options: {
-          "language_in": "ECMASCRIPT5",
-          "formatting": "PRETTY_PRINT",
-          "summary_detail_level": 3,
-          "warning_level": "VERBOSE",
-          "compilation_level": "SIMPLE_OPTIMIZATIONS",
-          "output_wrapper": "<%= grunt.file.read('scripts/output_wrapper.txt') %>",
-          "externs": "./src/js/externs/externs.js"
+          'language_in': 'ECMASCRIPT5',
+          'formatting': 'PRETTY_PRINT',
+          'summary_detail_level': 3,
+          'warning_level': 'VERBOSE',
+          'compilation_level': 'SIMPLE_OPTIMIZATIONS',
+          'output_wrapper': "<%= grunt.file.read('scripts/output_wrapper.txt') %>",
+          'externs': './src/js/externs/externs.js'
         }
       }
     },
+
     qunit: {
       all: ['test/index.html']
+    },
+
+    copy: {
+      dist: {
+        expand: true,
+        cwd: '.tmp/build',
+        src: '**/*',
+        dest: 'dist/js'
+      }
+    },
+
+    clean: {
+      all: ['.tmp', 'dist']
+    },
+
+    bump: {
+      options: {
+        prereleaseName: 'rc',
+        files: ['package.json', 'bower.json'],
+        updateConfigs: ['pkg'],
+        pushTo: "<%= grunt.config.get('gh-release.remote') %>",
+        commitFiles: ['package.json', "<%= grunt.config.get('changelog') %>", 'bower.json', 'dist']
+      }
+    },
+
+    prompt: {
+      'gh-release': {
+        options: {
+          questions: [
+            {
+              config: 'gh-release.remote',
+              type: 'input',
+              message: 'Git Remote (usually upstream or origin)',
+              default: 'upstream',
+              validate: function(val) {
+                return (grunt.util._.size(val) > 0);
+              }
+            },
+            {
+              config: 'gh-release.repo',
+              type: 'input',
+              message: 'Github Repository',
+              default: 'GoogleChrome/accessibility-developer-tools',
+              validate: function(val) {
+                return (grunt.util._.size(val) > 0);
+              }
+            },
+            {
+              config: 'gh-release.username',
+              type: 'input',
+              message: 'Github Username',
+              validate: function(val) {
+                return (grunt.util._.size(val) > 0);
+              }
+            },
+            {
+              config: 'gh-release.password',
+              type: 'password',
+              message: 'Github Password or Token',
+              validate: function(val) {
+                return (grunt.util._.size(val) > 0);
+              }
+            }
+          ]
+        }
+      }
     }
   });
 
-  grunt.loadNpmTasks('grunt-closurecompiler');
-  grunt.loadNpmTasks('grunt-contrib-qunit');
+  grunt.registerTask('changelog', function(type) {
+    grunt.task.requires('bump-only:' + type);
+
+    var config = {
+      data: {
+        version: grunt.config.get('pkg.version'),
+        releaseDate: grunt.template.today("yyyy-mm-dd")
+      }
+    };
+
+    var stopRegex = /^\#\#\ [0-9]+.*$/m;
+    var stopIndex = 0;
+    var releaseNotes = '';
+    var dest = grunt.config.get('changelog');
+    var contents = grunt.file.read(dest);
+    var headerTpl = "## <%= version %> - <%= releaseDate %>\n\n";
+    var header = grunt.template.process(headerTpl, config);
+
+    if (contents.length > 0) {
+      if ((stopIndex = contents.search(stopRegex)) !== -1) {
+        releaseNotes = contents.slice(0, stopIndex);
+      }
+    }
+
+    grunt.config.set("gh-release.release-notes", releaseNotes);
+
+    grunt.file.write(dest, "" + header + contents);
+    grunt.log.ok("Changelog updated, and release notes extracted.");
+  });
+
+  grunt.registerTask('gh-release', function() {
+    var config = grunt.config.get('gh-release');
+    var pkg = grunt.config.get('pkg');
+    var done = this.async();
+
+    request
+      .post('https://api.github.com/repos/' + config.repo + '/releases')
+      .auth(config.username, config.password)
+      .set('Accept', 'application/vnd.github.v3')
+      .set('User-Agent', 'grunt')
+      .send({
+        'tag_name': 'v' + pkg.version,
+        name: pkg.version,
+        body: config['release-notes'],
+        draft: true
+      })
+      .end(function(err, res){
+        if (typeof err !== "undefined" && err !== null) {
+          grunt.fail.warn('Error encountered while creating Github release.', err);
+        }
+
+        if (res.statusCode === 201){
+          grunt.log.ok('Github release created');
+          done();
+        } else {
+          grunt.fail.warn('Unable to create github release.', res.text);
+        }
+      });
+  });
 
   grunt.registerTask('git-describe', function() {
-    var _spawn = require("grunt-util-spawn")(grunt);
-
     // Start async task
     var done = this.async();
 
-    _spawn({
-      "cmd" : "git",
-      "args" : [ "rev-parse", "HEAD" ],
-      "opts" : {
-        "cwd" : "."
+    grunt.util.spawn({
+      'cmd' : 'git',
+      'args' : [ 'rev-parse', 'HEAD' ],
+      'opts' : {
+        'cwd' : '.'
       }
-      }, function(err, result) {
+    }, function(err, result) {
       if (err) {
           grunt.log.error(err).verbose.error(result);
           done();
@@ -69,20 +194,34 @@ module.exports = function(grunt) {
     });
   });
 
+  grunt.registerTask('release', function(releaseType) {
+    if (typeof releaseType === 'undefined' || releaseType === null) {
+      grunt.fail.fatal('You must specify a release type. i.e. grunt release:prerelease');
+    }
+
+    grunt.task.run([
+      'prompt:gh-release',
+      'build',
+      'test:unit',
+      'copy:dist',
+      'bump-only:' + releaseType,
+      'changelog:' + releaseType,
+      'bump-commit',
+      'gh-release'
+    ]);
+  });
+
   grunt.registerTask('save-revision', function() {
     grunt.event.once('git-describe', function (rev) {
-      grunt.log.writeln("Git Revision: " + rev);
+      grunt.log.writeln('Git Revision: ' + rev);
       grunt.config.set('git-revision', rev);
     });
     grunt.task.run('git-describe');
   });
 
-  grunt.registerTask('copy-dist', function() {
-    grunt.file.copy('gen/axs_testing.js', 'dist/js/axs_testing.js');
-  });
-
-  grunt.registerTask('default', ['save-revision', 'closurecompiler:minify', 'qunit']);
-  grunt.registerTask('build', ['default', 'copy-dist']);
-  grunt.registerTask('travis', ['closurecompiler:minify', 'qunit']);
+  grunt.registerTask('build', ['clean:all', 'save-revision', 'closurecompiler:minify']);
+  grunt.registerTask('test:unit', ['qunit']);
+  grunt.registerTask('dist', ['build', 'copy:dist']);
+  grunt.registerTask('travis', ['closurecompiler:minify', 'test:unit']);
+  grunt.registerTask('default', ['build', 'test:unit']);
 };
-

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "url": "http://github.com/GoogleChrome/accessibility-developer-tools"
   },
   "devDependencies": {
+    "bluebird": "^2.9.27",
     "grunt": "^0.4.5",
     "grunt-bump": "^0.3.1",
     "grunt-cli": "^0.1.13",
     "grunt-closurecompiler": "^0.9.9",
     "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-qunit": "^0.7.0",
     "grunt-prompt": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,15 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-bump": "^0.3.1",
     "grunt-cli": "^0.1.13",
     "grunt-closurecompiler": "^0.9.9",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-qunit": "^0.7.0",
-    "grunt-util-spawn": "^0.0.2"
+    "grunt-prompt": "^1.3.0",
+    "load-grunt-tasks": "^3.2.0",
+    "superagent": "^1.2.0"
   },
   "scripts": {
     "test": "grunt travis --verbose"

--- a/src/util/gh_repo.coffee
+++ b/src/util/gh_repo.coffee
@@ -1,0 +1,69 @@
+request = require 'superagent'
+Promise = require 'bluebird'
+
+# Small utility class to interact with the Github v3 releases API.
+module.exports = class GHRepo
+  constructor: (@config = {}) ->
+    @baseUrl = "https://api.github.com/repos/#{@config.repo}"
+
+  _buildRequest: (req) ->
+    req
+      .auth @config.username, @config.password
+      .set 'Accept', 'application/vnd.github.v3'
+      .set 'User-Agent', 'grunt'
+
+  log: -> console.log.apply console, arguments
+
+  getReleaseByTagName: (tag) ->
+    # GET /repos/:owner/:repo/releases/tags/:tag
+    new Promise (resolve, reject) =>
+      @log 'GET', "#{@baseUrl}/releases/tags/#{tag}"
+      @_buildRequest(request.get "#{@baseUrl}/releases/tags/#{tag}")
+        .end (err, res) ->
+          return resolve() if res.statusCode is 404
+          return reject(err) if err?
+          return reject("Request failed") if res.statusCode isnt 200
+          resolve res.body
+
+  getReleases: (tag) ->
+    # GET /repos/:owner/:repo/releases
+    new Promise (resolve, reject) =>
+      @log 'GET', "#{@baseUrl}/releases"
+      @_buildRequest(request.get "#{@baseUrl}/releases")
+        .end (err, res) ->
+          return resolve() if res.statusCode is 404
+          return reject(err) if err?
+          return reject("Request failed") if res.statusCode isnt 200
+          resolve res.body
+
+  updateRelease: (release, payload) ->
+    # PATCH /repos/:owner/:repo/releases/:id
+    new Promise (resolve, reject) =>
+      @log 'PATCH', "#{@baseUrl}/releases/#{release.id}"
+      @_buildRequest(request.patch "#{@baseUrl}/releases/#{release.id}")
+        .send payload
+        .end (err, res) ->
+          return reject(err) if err?
+          return reject("Request failed") if res.statusCode isnt 200
+          resolve res.body
+
+  createRelease: (payload) ->
+    # POST /repos/:owner/:repo/releases
+    new Promise (resolve, reject) =>
+      @log 'POST', "#{@baseUrl}/releases"
+      @_buildRequest(request.post "#{@baseUrl}/releases")
+        .send payload
+        .end (err, res) ->
+          return reject(err) if err?
+          return reject("Request failed") if res.statusCode isnt 201
+          resolve res.body
+
+  getReleaseByName: (name) ->
+    new Promise (resolve, reject) =>
+      @getReleases().then (releases = []) ->
+        for release in releases
+          return resolve(release) if release.name is name
+
+        return resolve()
+      .catch (err) ->
+        reject "Unable to fetch project releases."


### PR DESCRIPTION
This PR provides tooling for automating a lot of the `grunt` work involved in shipping out new releases.

Along with some general cleanups and enhancements (see below), the major change is the introduction of the `grunt release` task, which will perform the following tasks:

* Prompt the operator for release information (git remote, github repo info, etc...).
* Create a new build.
* Run the full suite of unit tests (currently against the source, but I'd like to make tests run against compiled bundle in the future).
* Copy the build into `dist/`.
* Bump `version` field in `package.json` and `bower.json`.
* Extract release notes from the changelog (everything above the last release header).
* Add the new release header to the changelog.
* Commit and push `package.json`, `bower.json`, `dist`.
* Create and push new git tag for the new release.
* Create a new github release against the new release tag and populate it with the release notes.

The task takes a `type` parameter, applied through the CLI as `grunt release:<type>`, where `type` is based on the `grunt-bump` plug-in.

Usage examples:

`grunt release:patch`
`grunt release:minor`
`grunt release:major`
`grunt release:2.9.5`

Minor cleanups and enhancements:

* Move temporary build artifacts to `.tmp`, and add that path to `.gitignore`.
* Normalize quotes across `Gruntfile.js` to use single quotes everywhere.
* Add `grunt clean` task to clean up `.tmp` and `dist/` automatically.
* `build` task no longer copies the compiled bundle anywhere. It's used as a low-level task now.
* New `test:unit` task wraps `qunit`.