### PR TITLE
Use SPDX License IDs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "testing",
     "WCAG"
   ],
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "ignore": [
     "**/.*",
     "lib",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "WCAG"
   ],
   "author": "Google",
-  "license": "Apache License 2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
* Both NPM and Bower specify that the `license` field should be a valid
SPDX license ID.
  * https://github.com/bower/bower.json-spec#license
  * https://docs.npmjs.com/files/package.json#license