### PR TITLE
Add support for config payload for AuditConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ To include just the javascript rules, require the following file:
 
     https://raw.github.com/GoogleChrome/accessibility-developer-tools/stable/dist/js/axs_testing.js
 
-  `git 1.6.5` or later: 
+  `git 1.6.5` or later:
 
     % git clone --recursive https://github.com/GoogleChrome/accessibility-developer-tools.git
-    
+
   Before `git 1.6.5`:
 
     % git clone https://github.com/GoogleChrome/accessibility-developer-tools.git
@@ -83,7 +83,7 @@ The runner will load the specified file or URL in a headless browser, inject axs
        "accessibility-developer-tools/stable/dist/js/axs_testing.js").mkString)
      val report = js.executeScript("var results = axs.Audit.run();return axs.Audit.createReport(results);")
      println(report)
-    
+
 ### Run audit from Selenium WebDriver (Scala)(with caching):
      val cache = collection.mutable.Map[String, String]()
      val driver = org.openqa.selenium.firefox.FirefoxDriver //use driver of your choice
@@ -99,7 +99,7 @@ The runner will load the specified file or URL in a headless browser, inject axs
        "accessibility-developer-tools/stable/dist/js/axs_testing.js"))
      val report = js.executeScript("var results = axs.Audit.run();return axs.Audit.createReport(results);")
      println(report)
-    
+
 If println() outputs nothing, check if you need to set DesiredCapabilities for your WebDriver (such as loggingPrefs):
 https://code.google.com/p/selenium/wiki/DesiredCapabilities
 
@@ -182,7 +182,18 @@ You can set a `scope` on the `AuditConfiguration` object like this:
     var configuration = new axs.AuditConfiguration();
     configuration.scope = document.querySelector('main');  // or however you wish to choose your scope element
     axs.Audit.run(configuration);
-    
+
+You may also specify a configuration payload while instantiating the `axs.AuditConfiguration`,
+which allows you to provide multiple configuration options at once.
+
+    var configuration = new axs.AuditConfiguration({
+      auditRulesToRun: ['badAriaRole'],
+      scope: document.querySelector('main'),
+      maxResults: 5
+    });
+
+    axs.Audit.run(configuration);
+
 ## License
 
 Copyright 2013 Google Inc. All Rights Reserved.

--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -20,9 +20,22 @@ goog.provide('axs.Audit');
 goog.provide('axs.AuditConfiguration');
 
 /**
+ * @typedef {{
+ *   scope: (Element|undefined),
+ *   auditRulesToRun: (Array.<String>|undefined),
+ *   auditRulesToIgnore: (Array.<String>|undefined),
+ *   maxResults: (number|undefined),
+ *   withConsoleApi: (boolean|undefined),
+ *   showUnsupportedRulesWarning: (boolean|undefined)
+ * }}
+ */
+axs.AuditConfigurationOptions_;
+
+
+/**
  * Object to hold configuration for an Audit run.
  * @constructor
- * @param {?Object=} config Configuration object
+ * @param {?axs.AuditConfigurationOptions_=} config Configuration object
  */
 axs.AuditConfiguration = function(config) {
     if (config == null) {

--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -22,8 +22,13 @@ goog.provide('axs.AuditConfiguration');
 /**
  * Object to hold configuration for an Audit run.
  * @constructor
+ * @param {?Object=} config Configuration object
  */
-axs.AuditConfiguration = function() {
+axs.AuditConfiguration = function(config) {
+    if (config == null) {
+        config = {};
+    }
+
     /**
      * Dictionary of { audit rule name : { rules } } where rules is a dictionary
      * of { rule type : value }.
@@ -77,6 +82,12 @@ axs.AuditConfiguration = function() {
      * @type {boolean}
      */
     this.showUnsupportedRulesWarning = true;
+
+    for (var prop in this) {
+        if ((this.hasOwnProperty(prop)) && (prop in config)) {
+            this[prop] = config[prop];
+        }
+    }
 
     goog.exportProperty(this, 'scope', this.scope);
     goog.exportProperty(this, 'auditRulesToRun', this.auditRulesToRun);

--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -19,23 +19,18 @@ goog.require('axs.utils');
 goog.provide('axs.Audit');
 goog.provide('axs.AuditConfiguration');
 
-/**
- * @typedef {{
- *   scope: (Element|undefined),
- *   auditRulesToRun: (Array.<String>|undefined),
- *   auditRulesToIgnore: (Array.<String>|undefined),
- *   maxResults: (number|undefined),
- *   withConsoleApi: (boolean|undefined),
- *   showUnsupportedRulesWarning: (boolean|undefined)
- * }}
- */
-axs.AuditConfigurationOptions_;
-
 
 /**
  * Object to hold configuration for an Audit run.
  * @constructor
- * @param {?axs.AuditConfigurationOptions_=} config Configuration object
+ * @param {?Object=} config Configuration object
+ *   The following configuration options are supported:
+ *   - scope
+ *   - auditRulesToRun
+ *   - auditRulesToIgnore
+ *   - maxResults
+ *   - withConsoleApi
+ *   - showUnsupportedRulesWarning
  */
 axs.AuditConfiguration = function(config) {
     if (config == null) {

--- a/test/js/audit-configuration-test.js
+++ b/test/js/audit-configuration-test.js
@@ -46,6 +46,22 @@ test("Configure severity of an audit rule", function() {
   }
 });
 
+test("Specify configuration as an object", function() {
+  var fixtures = document.getElementById('qunit-fixture');
+  
+  var configPayload = {
+    auditRulesToRun: ['badAriaRole'],
+    scope: fixtures,
+    maxResults: 1
+  };
+
+  var auditConfig = new axs.AuditConfiguration(configPayload);
+
+  for (var k in configPayload) {
+    equal(auditConfig[k], configPayload[k]);
+  }
+});
+
 test("Configure the number of results returned", function() {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');


### PR DESCRIPTION
* Overwrite `AuditConfiguration` properties defined in the constructor with properties found in payload parameter.
* Add test for new behaviour.
* Add usage example in docs.
* Fixes #164