### PR TITLE
non-production url added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There is also a collection of accessibility-related utility code, including but 
 
 To include just the javascript rules, require the following file:
 
-    https://raw.github.com/GoogleChrome/accessibility-developer-tools/stable/dist/js/axs_testing.js
+    https://rawgit.com/GoogleChrome/accessibility-developer-tools/stable/dist/js/axs_testing.js
 
   `git 1.6.5` or later: 
 


### PR DESCRIPTION
Refused to execute script from 'https://raw.github.com/GoogleChrome/accessibility-developer-tools/stable/dist/js/axs_testing.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.

This is to prevent this error 
see http://stackoverflow.com/questions/17341122/link-and-execute-external-javascript-file-hosted-on-github