### PR TITLE
Fixes issue #183

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
 
 * A label element may not have labelable descendants other than its labeled control (`src/audits/MultipleLabelableElementsPerLabel.js`)
 
+### Bug fixes:
+
+* Work around null pointer exception caused by closure compiler issue (#183).
+
 ## 2.8.0 - 2015-07-24
 
 ## 2.8.0-rc.0 - 2015-07-10

--- a/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
+++ b/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
@@ -43,7 +43,7 @@ axs.AuditRules.addRule({
         // Ignore elements which have a negative tabindex and no text content,
         // as they will be skipped by assistive technology
         var textAlternatives = axs.properties.findTextAlternatives(element, {});
-        if (!textAlternatives || textAlternatives.trim() === '')
+        if (textAlternatives == null || textAlternatives.trim() === '')
             return false;
 
         return true;

--- a/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
+++ b/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
@@ -43,7 +43,7 @@ axs.AuditRules.addRule({
         // Ignore elements which have a negative tabindex and no text content,
         // as they will be skipped by assistive technology
         var textAlternatives = axs.properties.findTextAlternatives(element, {});
-        if (textAlternatives == null || textAlternatives.trim() === '')
+        if (textAlternatives === null || textAlternatives.trim() === '')
             return false;
 
         return true;


### PR DESCRIPTION
Actually this is a workaround, not a fix because the bug is in closure compiler. I'll break it down in detail below.

First understand that the function `axs.properties.findTextAlternatives` can legitimately return `null`.
Then take a look at the way we call it:

```
var textAlternatives = axs.properties.findTextAlternatives(element, {});
if (!textAlternatives || textAlternatives.trim() === '')
```

All good. But then take a look at what closure compiler produces:
```
return "" === axs.properties.findTextAlternatives(a, {}).trim() ? !1 : !0;
```
That will throw an exception if the return value is null.
The easiest workaround is to get closure compiler to produce something else. The proposed change does not change the logic of the audit but results in safe code generated by closure compiler:
```
a = axs.properties.findTextAlternatives(a, {});
  return null == a || "" === a.trim() ? !1 : !0;
```