### PR TITLE
Add .matches() as default choice for browserUtils.matchSelector

### DIFF
--- a/src/js/BrowserUtils.js
+++ b/src/js/BrowserUtils.js
@@ -15,6 +15,7 @@
 goog.provide('axs.browserUtils');
 
 /**
+ * Use Webkit matcher when matches() is not supported.
  * Use Firefox matcher when Webkit is not supported.
  * Use IE matcher when neither webkit nor Firefox supported.
  * @param {Element} element
@@ -22,6 +23,8 @@ goog.provide('axs.browserUtils');
  * @return {boolean} true if the element matches the selector
  */
 axs.browserUtils.matchSelector = function(element, selector) {
+    if (element.matches)
+        return element.matches(selector);
     if (element.webkitMatchesSelector)
         return element.webkitMatchesSelector(selector);
     if (element.mozMatchesSelector)


### PR DESCRIPTION
Formerly known as matchesSelector(), with many vendor prefixes as seen in this function.
I'm using ADT in a jsdom environment, which doesn't support any vendor-prefixed variations
of this function.

http://caniuse.com/#feat=matchesselector