### PR TITLE
Fixes issue #182 and adds a unit test to check this condition.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes:
 
+* Fix `badAriaAttributeValue` not correctly handling decimal values (#182).
 * Work around null pointer exception caused by closure compiler issue (#183).
 
 ## 2.8.0 - 2015-07-24

--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -654,7 +654,6 @@ axs.utils.getRoles = function(element, implicit) {
             roleObject.valid = result.valid = true;
         } else {
             roleObject.valid = false;
-
         }
         result.roles.push(roleObject);
     }
@@ -722,11 +721,13 @@ axs.utils.getAriaPropertyValue = function(propertyName, value, element) {
     case "decimal":
     case "number":
         var validNumber = axs.utils.isValidNumber(value);
+        result.valid = validNumber.valid;
         if (!validNumber.valid) {
-            result.valid = false;
             result.reason = validNumber.reason;
             return result;
         }
+        result.value = validNumber.value;
+        return result;
     case "string":
         result.valid = true;
         result.value = value;

--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -654,7 +654,7 @@ axs.utils.getRoles = function(element, implicit) {
             roleObject.valid = result.valid = true;
         } else {
             roleObject.valid = false;
-            
+
         }
         result.roles.push(roleObject);
     }
@@ -705,14 +705,13 @@ axs.utils.getAriaPropertyValue = function(propertyName, value, element) {
         }
         return result;
     case "integer":
-    case "decimal":
         var validNumber = axs.utils.isValidNumber(value);
         if (!validNumber.valid) {
             result.valid = false;
             result.reason = validNumber.reason;
             return result;
         }
-        if (Math.floor(validNumber.value) != validNumber.value) {
+        if (Math.floor(validNumber.value) !== validNumber.value) {
             result.valid = false;
             result.reason = '' + value + ' is not a whole integer';
         } else {
@@ -720,11 +719,13 @@ axs.utils.getAriaPropertyValue = function(propertyName, value, element) {
             result.value = validNumber.value;
         }
         return result;
+    case "decimal":
     case "number":
         var validNumber = axs.utils.isValidNumber(value);
-        if (validNumber.valid) {
-            result.valid = true;
-            result.value = validNumber.value;
+        if (!validNumber.valid) {
+            result.valid = false;
+            result.reason = validNumber.reason;
+            return result;
         }
     case "string":
         result.valid = true;

--- a/test/audits/bad-aria-attribute-value-test.js
+++ b/test/audits/bad-aria-attribute-value-test.js
@@ -32,3 +32,25 @@ test('Good number value is good', function() {
       { elements: [], result: axs.constants.AuditResult.PASS }
     );
 });
+
+test('Good decimal number value is good', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var div = document.createElement('div');
+    fixture.appendChild(div);
+    div.setAttribute('aria-valuenow', '0.5');
+    deepEqual(
+      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
+      { elements: [], result: axs.constants.AuditResult.PASS }
+    );
+});
+
+test('Good negative number value is good', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var div = document.createElement('div');
+    fixture.appendChild(div);
+    div.setAttribute('aria-valuenow', '-10');
+    deepEqual(
+      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
+      { elements: [], result: axs.constants.AuditResult.PASS }
+    );
+});


### PR DESCRIPTION
Looks like the intent was for `decimal` and `number` to be validated the same way instead of `decimal` and `integer`.