### PR TITLE
Add a special case to handle color `"transparent"` to fix #180.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 ### Bug fixes:
 
 * Work around null pointer exception caused by closure compiler issue (#183).
+* Add a special case to handle color `"transparent"` to fix #180.
 
 ## 2.8.0 - 2015-07-24
 

--- a/src/js/Color.js
+++ b/src/js/Color.js
@@ -137,6 +137,9 @@ axs.color.luminanceRatio = function(luminance1, luminance2) {
  * @return {?axs.color.Color}
  */
 axs.color.parseColor = function(colorString) {
+    if(colorString === "transparent") {
+        return new axs.color.Color(0, 0, 0, 0);
+    }
     var rgbRegex = /^rgb\((\d+), (\d+), (\d+)\)$/;
     var match = colorString.match(rgbRegex);
 

--- a/test/js/color-test.js
+++ b/test/js/color-test.js
@@ -43,6 +43,25 @@ test("parses alpha values correctly", function() {
   equal(color.alpha, .47);
 });
 
+test("handles rgba transparent value correctly", function() {
+  var colorString = 'rgba(0, 0, 0, 0)';
+  var color = axs.color.parseColor(colorString);
+  equal(color.red, 0);
+  equal(color.blue, 0);
+  equal(color.green, 0);
+  equal(color.alpha, 0);
+});
+
+test("handles xbrowser 'transparent' value correctly", function() {
+  // Firefox, IE11, Project Spartan (MS Edge Release Candidate)
+  var colorString = 'transparent';
+  var color = axs.color.parseColor(colorString);
+  equal(color.red, 0);
+  equal(color.blue, 0);
+  equal(color.green, 0);
+  equal(color.alpha, 0);
+});
+
 module("suggestColors");
 test("suggests correct grey values", function() {
   var white = new axs.color.Color(255, 255, 255, 1)

--- a/test/js/color-test.js
+++ b/test/js/color-test.js
@@ -54,6 +54,7 @@ test("handles rgba transparent value correctly", function() {
 
 test("handles xbrowser 'transparent' value correctly", function() {
   // Firefox, IE11, Project Spartan (MS Edge Release Candidate)
+  // See #180 https://github.com/GoogleChrome/accessibility-developer-tools/issues/180
   var colorString = 'transparent';
   var color = axs.color.parseColor(colorString);
   equal(color.red, 0);


### PR DESCRIPTION
Fixes issue #180 
This bug is responsible for the only failing unit test (`LowContrast - "Opacity is handled"`) in:
* Firefox
* IE11
* MS Edge

This fix makes 100% of unit tests pass in those browsers.

Also checked Chrome, Opera and Safari, all 100%.