### PR TITLE
Fix ARIA tablist and ARIA tab scope

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 * Add a special case to handle color `"transparent"` to fix (#180).
 * Fix `matchSelector` not working properly in browser environments without vendor prefixes (#189).
 * Fix false positives on elements with no role for Unsupported ARIA Attribute rule (#178 and #199).
+* Fix ARIA `tablist` and ARIA `tab` scope (#204)
 
 ## 2.8.0 - 2015-07-24
 

--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -413,8 +413,7 @@ axs.constants.ARIA_ROLES = {
         "mustcontain": [ "tab" ],
         "namefrom": [ "author" ],
         "parent": [ "composite", "directory" ],
-        "properties": [ "aria-level" ],
-        "scope": [ "tablist" ]
+        "properties": [ "aria-level" ]
     },
     "tabpanel": {
         "namefrom": [ "author" ],

--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -407,7 +407,8 @@ axs.constants.ARIA_ROLES = {
     "tab": {
         "namefrom": [ "contents", "author" ],
         "parent": [ "sectionhead", "widget" ],
-        "properties": [ "aria-selected" ]
+        "properties": [ "aria-selected" ],
+        "scope": [ "tablist" ]
     },
     "tablist": {
         "mustcontain": [ "tab" ],

--- a/test/audits/aria-role-not-scoped-test.js
+++ b/test/audits/aria-role-not-scoped-test.js
@@ -98,9 +98,10 @@ test('Scope role present - tablist', function() {
 test('Scope role missing - tab', function() {
     var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
     var fixture = document.getElementById('qunit-fixture');
+    var container = fixture.appendChild(document.createElement('ul'));
     var expected = [];
     for (var i = 0; i < 4; i++) {
-        var item = fixture.appendChild(document.createElement('span'));
+        var item = container.appendChild(document.createElement('li'));
         item.setAttribute('role', 'tab');
         expected.push(item);
     }

--- a/test/audits/aria-role-not-scoped-test.js
+++ b/test/audits/aria-role-not-scoped-test.js
@@ -94,3 +94,18 @@ test('Scope role present - tablist', function() {
     equal(actual.result, axs.constants.AuditResult.PASS);
     deepEqual(actual.elements, []);
 });
+
+test('Scope role missing - tab', function() {
+    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+    var fixture = document.getElementById('qunit-fixture');
+    var expected = [];
+    for (var i = 0; i < 4; i++) {
+        var item = fixture.appendChild(document.createElement('span'));
+        item.setAttribute('role', 'tab');
+        expected.push(item);
+    }
+
+    var actual = rule.run({ scope: fixture });
+    equal(actual.result, axs.constants.AuditResult.FAIL);
+    deepEqual(actual.elements, expected);
+});

--- a/test/audits/aria-role-not-scoped-test.js
+++ b/test/audits/aria-role-not-scoped-test.js
@@ -79,3 +79,18 @@ test('Scope role missing', function() {
     equal(actual.result, axs.constants.AuditResult.FAIL);
     deepEqual(actual.elements, expected);
 });
+
+test('Scope role present - tablist', function() {
+    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+    var fixture = document.getElementById('qunit-fixture');
+    var container = fixture.appendChild(document.createElement('ul'));
+    container.setAttribute('role', 'tablist');
+    for (var i = 0; i < 4; i++) {
+        var item = container.appendChild(document.createElement('li'));
+        item.setAttribute('role', 'tab');
+    }
+
+    var actual = rule.run({ scope: fixture });
+    equal(actual.result, axs.constants.AuditResult.PASS);
+    deepEqual(actual.elements, []);
+});


### PR DESCRIPTION
Closes #204 
The required context role for `tab` ended up on `tablist` instead.

This motivates me to get onto #105  