### PR TITLE
Link with unclear purpose audit handles img with alt and aria-label

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 * Add a special case to handle color `"transparent"` to fix (#180).
 * Fix `matchSelector` not working properly in browser environments without vendor prefixes (#189).
 * Fix false positives on elements with no role for Unsupported ARIA Attribute rule (#178 and #199).
+* Fix link with clear purpose with text alternative (#156);
 
 ## 2.8.0 - 2015-07-24
 

--- a/src/audits/LinkWithUnclearPurpose.js
+++ b/src/audits/LinkWithUnclearPurpose.js
@@ -56,7 +56,9 @@ axs.AuditRules.addRule({
         // all whitespace.
         var stopwords = config['stopwords'] ||
             ['click', 'tap', 'go', 'here', 'learn', 'more', 'this', 'page', 'link', 'about'];
-        var filteredText = anchor.textContent;
+        var filteredText = axs.properties.findTextAlternatives(anchor, {});
+        if (filteredText === null || filteredText.trim() === '')
+            return true;
         filteredText = filteredText.replace(/[^a-zA-Z ]/g, '');
         for (var i = 0; i < stopwords.length; i++) {
             var stopwordRE = new RegExp('\\b' + stopwords[i] + '\\b', 'ig');

--- a/test/audits/link-with-unclear-purpose.js
+++ b/test/audits/link-with-unclear-purpose.js
@@ -27,6 +27,63 @@ test('a link with meaningful text is good', function() {
         { elements: [], result: axs.constants.AuditResult.PASS });
 });
 
+test('a link with an img with meaningful alt text is good', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var a = document.createElement('a');
+    a.href = '#main';
+    var img = a.appendChild(document.createElement('img'));
+    img.setAttribute('alt', 'Learn more about trout fishing');
+
+    fixture.appendChild(a);
+    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    deepEqual(
+        rule.run({scope: fixture}),
+        { elements: [], result: axs.constants.AuditResult.PASS });
+});
+
+test('a link with an img with meaningless alt text is bad', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var a = document.createElement('a');
+    a.href = '#main';
+    var img = a.appendChild(document.createElement('img'));
+    img.setAttribute('alt', 'Click here!');
+
+    fixture.appendChild(a);
+    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    deepEqual(rule.run({scope: fixture}),
+        { elements: [a], result: axs.constants.AuditResult.FAIL });
+});
+
+test('a link with meaningful aria-label is good', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    // Style our link to be visually meaningful with no descendent nodes at all.
+    fixture.innerHTML = '<style>a.trout::after{content: "Learn more about trout fishing"}</style>';
+    var a = document.createElement('a');
+    a.href = '#main';
+    a.className = 'trout';
+    a.setAttribute('aria-label', 'Learn more about trout fishing');
+    fixture.appendChild(a);
+    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    deepEqual(
+        rule.run({scope: fixture}),
+        { elements: [], result: axs.constants.AuditResult.PASS });
+});
+
+test('a link with meaningful aria-label is good', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    // Style our link to be visually meaningful with no descendent nodes at all.
+    fixture.innerHTML = '<style>a.trout::after{content: "Learn more about trout fishing"}</style>';
+    var a = document.createElement('a');
+    a.href = '#main';
+    a.className = 'trout';
+    a.setAttribute('aria-label', 'Learn more about trout fishing');
+    fixture.appendChild(a);
+    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    deepEqual(
+        rule.run({scope: fixture}),
+        { elements: [], result: axs.constants.AuditResult.PASS });
+});
+
 test('a link without meaningful text is bad', function() {
     var fixture = document.getElementById('qunit-fixture');
     var a = document.createElement('a');

--- a/test/audits/link-with-unclear-purpose.js
+++ b/test/audits/link-with-unclear-purpose.js
@@ -69,15 +69,19 @@ test('a link with meaningful aria-label is good', function() {
         { elements: [], result: axs.constants.AuditResult.PASS });
 });
 
-test('a link with meaningful aria-label is good', function() {
+test('a link with meaningful aria-labelledby is good', function() {
     var fixture = document.getElementById('qunit-fixture');
     // Style our link to be visually meaningful with no descendent nodes at all.
     fixture.innerHTML = '<style>a.trout::after{content: "Learn more about trout fishing"}</style>';
     var a = document.createElement('a');
     a.href = '#main';
     a.className = 'trout';
-    a.setAttribute('aria-label', 'Learn more about trout fishing');
+    var label = document.createElement('span');
+    label.textContent = 'Learn more about trout fishing';
+    label.id = "trout" + Date.now();
+    a.setAttribute('aria-labelledby', label.id);
     fixture.appendChild(a);
+    fixture.appendChild(label);
     var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
     deepEqual(
         rule.run({scope: fixture}),

--- a/test/audits/link-with-unclear-purpose.js
+++ b/test/audits/link-with-unclear-purpose.js
@@ -54,6 +54,9 @@ test('a link with an img with meaningless alt text is bad', function() {
         { elements: [a], result: axs.constants.AuditResult.FAIL });
 });
 
+/*
+ * This test will need to be reviewed when issue #214 is addressed.
+ */
 test('a link with meaningful aria-label is good', function() {
     var fixture = document.getElementById('qunit-fixture');
     // Style our link to be visually meaningful with no descendent nodes at all.
@@ -69,6 +72,9 @@ test('a link with meaningful aria-label is good', function() {
         { elements: [], result: axs.constants.AuditResult.PASS });
 });
 
+/*
+ * This test will need to be reviewed when issue #214 is addressed.
+ */
 test('a link with meaningful aria-labelledby is good', function() {
     var fixture = document.getElementById('qunit-fixture');
     // Style our link to be visually meaningful with no descendent nodes at all.
@@ -101,4 +107,19 @@ test('a link without meaningful text is bad', function() {
         deepEqual(rule.run({scope: fixture}),
                   { elements: [a], result: axs.constants.AuditResult.FAIL });
     });
+});
+
+test('a link with bg image and meaningful aria-label is good', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    // Style our link to be visually meaningful with no descendent nodes at all.
+    fixture.innerHTML = '<style>a.trout{background-image: url("/trout.png"); display:block; height:1em}</style>';
+    var a = document.createElement('a');
+    a.href = '#main';
+    a.className = 'trout';
+    a.setAttribute('aria-label', 'Learn more about trout fishing');
+    fixture.appendChild(a);
+    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    deepEqual(
+        rule.run({scope: fixture}),
+        { elements: [], result: axs.constants.AuditResult.PASS });
 });


### PR DESCRIPTION
This PR allows links to be labelled by their textcontent (as before) and additionally:

* aria-label
* aria-labelledby
* img with alt text

There is no way for us to truly validate the the link is *visually* meaningful since it would be really hard to analyse what the image looks like - this really only confirms that the link is meaningful to AT.

@alice PTAL