### PR TITLE
Fixes issue #217 findTextAlternatives not ignoring hidden elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 * Add a special case to handle color `"transparent"` to fix (#180).
 * Fix `matchSelector` not working properly in browser environments without vendor prefixes (#189).
 * Fix false positives on elements with no role for Unsupported ARIA Attribute rule (#178 and #199).
+* Fix `findTextAlternatives` not always correctly ignoring hidden elements (#217).
 
 ## 2.8.0 - 2015-07-24
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+### New rules
+
+### Enhancements
+
+### Bug fixes:
+
+* Fix `findTextAlternatives` not always correctly ignoring hidden elements (#217).
+* `findTextAlternatives` now honors `alt` attribute of input type image
+
 ## 2.9.0-rc.0 - 2015-08-21
 
 ### New rules

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,6 @@
 
 * Fix `findTextAlternatives` not always correctly ignoring hidden elements (#217).
 * `findTextAlternatives` now honors `alt` attribute of input type image
-
 * Revert #150 which was causing the extension not to work.
 
 ## 2.9.0 - 2015-09-04

--- a/src/js/Properties.js
+++ b/src/js/Properties.js
@@ -243,7 +243,7 @@ axs.properties.findTextAlternatives = function(node, textAlternatives, opt_recur
 
     // 1. Skip hidden elements unless the author specifies to use them via an aria-labelledby or
     // aria-describedby being used in the current computation.
-    if (!recursive && !opt_force && axs.utils.isElementOrAncestorHidden(element))
+    if (!opt_force && axs.utils.isElementOrAncestorHidden(element))
         return null;
 
     // if this is a text node, just return text content.

--- a/test/js/properties-test.js
+++ b/test/js/properties-test.js
@@ -93,6 +93,34 @@ test('Image with title', function() {
 });
 
 
+test('Link with aria-hidden text', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var anchor = fixture.appendChild(document.createElement('a'));
+    anchor.href = '#';
+    anchor.innerHTML = '<span aria-hidden="true">X</span><span>Close this window</span>';
+    var textAlternatives = {};
+    var result = axs.properties.findTextAlternatives(anchor, textAlternatives);
+    equal(1, Object.keys(textAlternatives).length, 'exactly one text alternative');
+    equal(true, 'content' in textAlternatives, 'content in textAlternatives');
+    equal('Close this window', textAlternatives.content.text);
+    equal('Close this window', result);
+});
+
+test('Link with aria-labelledby aria-hidden text', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var anchor = fixture.appendChild(document.createElement('a'));
+    anchor.href = '#';
+    anchor.setAttribute('aria-labelledby', 'foobar');
+    anchor.innerHTML = '<span id="foobar" aria-hidden="true">X</span><span>Close this window</span>';
+    var textAlternatives = {};
+    var result = axs.properties.findTextAlternatives(anchor, textAlternatives);
+    equal(2, Object.keys(textAlternatives).length, 'exactly two text alternatives');
+    equal(true, 'ariaLabelledby' in textAlternatives, 'ariaLabelledby in textAlternatives');
+    equal('Close this window', textAlternatives.content.text);
+    equal('X', textAlternatives.ariaLabelledby.text);
+    equal('X', result);
+});
+
 module('getTextFromHostLanguageAttributes', {
     setup: function () {
         this.fixture_ = document.getElementById('qunit-fixture');

--- a/test/js/properties-test.js
+++ b/test/js/properties-test.js
@@ -100,10 +100,10 @@ test('Link with aria-hidden text', function() {
     anchor.innerHTML = '<span aria-hidden="true">X</span><span>Close this window</span>';
     var textAlternatives = {};
     var result = axs.properties.findTextAlternatives(anchor, textAlternatives);
-    equal(1, Object.keys(textAlternatives).length, 'exactly one text alternative');
-    equal(true, 'content' in textAlternatives, 'content in textAlternatives');
-    equal('Close this window', textAlternatives.content.text);
-    equal('Close this window', result);
+    equal(Object.keys(textAlternatives).length, 1, 'exactly one text alternative');
+    equal('content' in textAlternatives, true, 'content in textAlternatives');
+    equal(textAlternatives.content.text, 'Close this window');
+    equal(result, 'Close this window');
 });
 
 test('Link with aria-labelledby aria-hidden text', function() {
@@ -114,11 +114,11 @@ test('Link with aria-labelledby aria-hidden text', function() {
     anchor.innerHTML = '<span id="foobar" aria-hidden="true">X</span><span>Close this window</span>';
     var textAlternatives = {};
     var result = axs.properties.findTextAlternatives(anchor, textAlternatives);
-    equal(2, Object.keys(textAlternatives).length, 'exactly two text alternatives');
-    equal(true, 'ariaLabelledby' in textAlternatives, 'ariaLabelledby in textAlternatives');
-    equal('Close this window', textAlternatives.content.text);
-    equal('X', textAlternatives.ariaLabelledby.text);
-    equal('X', result);
+    equal(Object.keys(textAlternatives).length, 2, 'exactly two text alternatives');
+    equal('ariaLabelledby' in textAlternatives, true, 'ariaLabelledby in textAlternatives');
+    equal(textAlternatives.content.text, 'Close this window');
+    equal(textAlternatives.ariaLabelledby.text, 'X');
+    equal(result, 'X');
 });
 
 module('getTextFromHostLanguageAttributes', {

--- a/test/js/properties-test.js
+++ b/test/js/properties-test.js
@@ -53,6 +53,19 @@ test('Image with alt text', function() {
     equal('Smile!', textAlternatives.alt.text);
 });
 
+test('Input type image with alt text', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var img = fixture.appendChild(document.createElement('input'));
+    img.type = "image";
+    img.src = 'smile.jpg';
+    img.alt = 'Smile!';
+    var textAlternatives = {};
+    axs.properties.findTextAlternatives(img, textAlternatives);
+    equal(Object.keys(textAlternatives).length, 1, 'exactly one text alternative');
+    equal('alt' in textAlternatives, true, 'alt in textAlternatives');
+    equal('Smile!', textAlternatives.alt.text);
+});
+
 test('Image with aria label', function() {
     var fixture = document.getElementById('qunit-fixture');
     var img = fixture.appendChild(document.createElement('img'));
@@ -121,6 +134,22 @@ test('Link with aria-labelledby aria-hidden text', function() {
     equal(result, 'X');
 });
 
+test('Link with aria-labelledby element with aria-label', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var anchor = fixture.appendChild(document.createElement('a'));
+    anchor.href = '#';
+    anchor.setAttribute('aria-labelledby', 'foobar');
+    var label = fixture.appendChild(document.createElement('span'));
+    label.setAttribute('id', 'foobar');
+    label.setAttribute('aria-label', 'Learn more about trout fishing');
+    var textAlternatives = {};
+    var result = axs.properties.findTextAlternatives(anchor, textAlternatives);
+    equal(Object.keys(textAlternatives).length, 1, 'exactly one text alternative');
+    equal('ariaLabelledby' in textAlternatives, true, 'ariaLabelledby in textAlternatives');
+    equal(textAlternatives.ariaLabelledby.text, 'Learn more about trout fishing');
+    equal(result, 'Learn more about trout fishing');
+});
+
 module('getTextFromHostLanguageAttributes', {
     setup: function () {
         this.fixture_ = document.getElementById('qunit-fixture');
@@ -179,27 +208,27 @@ test('Get focus properties', function() {
 });
 
 module("getTextFromDescendantContent", {
-  setup: function () {
-    this.fixture_ = document.getElementById('qunit-fixture');
-  }
+    setup: function () {
+        this.fixture_ = document.getElementById('qunit-fixture');
+    }
 });
 test("returns text from the descendants of the element", function() {
-  var html = '<label>\n' +
-             '  <input type="radio" id="reason_Screenshot" name="reason" value="screenshot"></input>\n' +
-             '</label>'
-  this.fixture_.innerHTML = html;
-  var targetNode = this.fixture_.querySelector('label');
+    var html = '<label>\n' +
+            '  <input type="radio" id="reason_Screenshot" name="reason" value="screenshot"></input>\n' +
+            '</label>';
+    this.fixture_.innerHTML = html;
+    var targetNode = this.fixture_.querySelector('label');
 
-  try {
-    equal(axs.properties.getTextFromDescendantContent(targetNode), "");
-    return ok(true);
-  } catch( e ) {
-    return ok(false, "Threw exception: " + e);
-  }
+    try {
+        equal(axs.properties.getTextFromDescendantContent(targetNode), '');
+        return ok(true);
+    } catch(e) {
+        return ok(false, 'Threw exception: ' + e);
+    }
 });
 
 module('getImplicitRole', {
-    setup: function () {}
+    setup: function() {}
 });
 
 test('get implicit role for button', function() {


### PR DESCRIPTION
This is kind of scary because `findTextAlternatives` is a big and complex routine and I'm worried that the proposed change might have implications I have not considered.

That said, it passes all existing and new unit tests which gives me enough confidence to say @alice PTAL.