### PR TITLE
Export all of axs when not using AMD

### DIFF
--- a/scripts/output_wrapper.txt
+++ b/scripts/output_wrapper.txt
@@ -29,5 +29,5 @@ var fn = (function() {
 if (typeof define !== 'undefined' && define.amd) {
   define([], fn);
 } else {
-  fn.call(this);
+  var axs = fn.call(this);
 }


### PR DESCRIPTION
This restores previous behavior that allowed access to `axs.utils`

We are using [a11y](https://github.com/addyosmani/a11y), which reformats the report for the CLI. They are using `axs.utils.getQuerySelectorText` to get a helpful description of the element which fails the audit ([see code here](https://github.com/addyosmani/a11y/blob/master/audits.js#L68)). When the AMD pattern was implemented, the fallback did not maintain previous behavior of exporting all of `axs`. This breaks output when using a11y.

The Pivotal UI Team
@atomanyih @ctaymor @gpleiss @kennyw12 @matt-royal @nicw @stubbornella