### PR TITLE
Fixes issue #225

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 * Handle edge cases in number parser, e.g. "+1", ".1", "01"
 * HTML button containing img with alt attribute now passes controlsWithoutLabel (#202)
 * Disabled elements should be ignored by low contrast audit (#205)
+* Fix input of type "text" did not find correct implied role (#225)
 
 ## 2.8.0 - 2015-07-24
 

--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -1440,8 +1440,11 @@ axs.constants.TAG_TO_IMPLICIT_SEMANTIC_INFO = {
         role: 'combobox',  // aria-owns is set to the same value as the list attribute
         selector: 'input[type="text"][list]'
     }, {
-        role: '',
+        role: 'textbox',
         selector: 'input[type="text"]:not([list])'
+    }, {
+        role: 'textbox',
+        selector: 'input:not([type])'
     }, {
         role: '',
         selector: 'input[type="time"]'

--- a/test/audits/unsupported-aria-attribute-test.js
+++ b/test/audits/unsupported-aria-attribute-test.js
@@ -142,4 +142,30 @@
         var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         deepEqual(rule.run({ scope: fixture }), expected);
     });
+
+    test('Input with no type attribute with no role and aria-required', function() {
+        var fixture = document.getElementById('qunit-fixture');
+        var widget = fixture.appendChild(document.createElement('input'));
+        widget.setAttribute('aria-required', 'true');
+        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
+        deepEqual(rule.run({ scope: fixture }), expected, 'An input with no type is a textbox');
+    });
+
+    test('Input with type=text attribute with no role and aria-required', function() {
+        var fixture = document.getElementById('qunit-fixture');
+        var widget = fixture.appendChild(document.createElement('input'));
+        widget.setAttribute('type', 'text');
+        widget.setAttribute('aria-required', 'true');
+        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
+        deepEqual(rule.run({ scope: fixture }), expected, 'A text input is a textbox');
+    });
+
+    test('Input with type=text property with no role and aria-required', function() {
+        var fixture = document.getElementById('qunit-fixture');
+        var widget = fixture.appendChild(document.createElement('input'));
+        widget.type = 'text';
+        widget.setAttribute('aria-required', 'true');
+        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
+        deepEqual(rule.run({ scope: fixture }), expected, 'A text input is a textbox');
+    });
 })();


### PR DESCRIPTION
Fixed the reported bug and found another related one we had not encountered yet - input with no `type` is a text input.

Actually an input of any unknown type is a text input - we probably don't handle that, that should probably be a separate issue..? For example `<input type="foo"/>` I'm thinking that's an outlier and no point holding up this fix for it.

Also completely ignoring the fact that `aria-required` should not be used when an exactly equivalent native attribute is available - that should be a different audit anyway because SEVERE is a bit extreme in that case.