### PR TITLE
Hidden links no longer fail meaningful link audit

### DIFF
--- a/src/audits/LinkWithUnclearPurpose.js
+++ b/src/audits/LinkWithUnclearPurpose.js
@@ -29,7 +29,7 @@ axs.AuditRules.addRule({
      * @return {boolean}
      */
     relevantElementMatcher: function(element) {
-        return axs.browserUtils.matchSelector(element, 'a');
+        return axs.browserUtils.matchSelector(element, 'a') && !axs.utils.isElementOrAncestorHidden(element);
     },
     /**
      * @param {Element} anchor

--- a/test/audits/link-with-unclear-purpose.js
+++ b/test/audits/link-with-unclear-purpose.js
@@ -123,3 +123,16 @@ test('a link with bg image and meaningful aria-label is good', function() {
         rule.run({scope: fixture}),
         { elements: [], result: axs.constants.AuditResult.PASS });
 });
+
+test('a hidden link should not be run against the audit', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var a = document.createElement('a');
+    a.hidden = true;
+    a.href = '#main';
+    a.textContent = 'Learn more about trout fishing';
+    fixture.appendChild(a);
+    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    deepEqual(
+      rule.run({scope: fixture}),
+      { result: axs.constants.AuditResult.NA });
+});


### PR DESCRIPTION
Links which were hidden were failing the LinkWithUnclearPurpose audit, because they were being audited, but findTextAlternatives wasn't returning their text.

The Pivotal UI Team
@atomanyih @ctaymor @d-reinhold @kennyw12 @matt-royal @nicw @stubbornella