### PR TITLE
changes ignoreSelectors to match documented behavior

### DIFF
--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -119,17 +119,34 @@ axs.AuditRule.prototype.addElement = function(elements, element) {
 };
 
 /**
+ * @param {Node} node
+ * @param {function(Element): boolean} matcher
+ * @param {Array<string>=} opt_ignoreSelectors The array of selectors to ignore, if any.
+ */
+axs.AuditRule.collectMatchingElements = function(node, matcher, collection, opt_ignoreSelectors) {
+    axs.AuditRule.collectMatchingElementsInternal(node, matcher, collection, null, opt_ignoreSelectors);
+};
+
+/**
  * Recursively collect elements which match |matcher| into |collection|,
  * starting at |node|.
  * @param {Node} node
  * @param {function(Element): boolean} matcher
  * @param {Array.<Element>} collection
- * @param {ShadowRoot=} opt_shadowRoot The nearest ShadowRoot ancestor, if any.
+ * @param {?ShadowRoot} opt_shadowRoot The nearest ShadowRoot ancestor, if any
+ * @param {Array<string>=} opt_ignoreSelectors The array of selectors to ignore, if any.
  */
-axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
-                                                 opt_shadowRoot) {
-    if (node.nodeType == Node.ELEMENT_NODE)
+axs.AuditRule.collectMatchingElementsInternal = function(node, matcher, collection, opt_shadowRoot, opt_ignoreSelectors) {
+    if (node.nodeType == Node.ELEMENT_NODE) {
         var element = /** @type {Element} */ (node);
+        if (opt_ignoreSelectors) {
+            for (var i = 0; i < opt_ignoreSelectors.length; i++) {
+                if (axs.browserUtils.matchSelector(element, opt_ignoreSelectors[i])) {
+                    return;
+                }
+            }
+        }
+    }
 
     if (element && matcher.call(null, element))
         collection.push(element);
@@ -141,12 +158,15 @@ axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
     if (element) {
         // NOTE: grunt qunit DOES NOT support Shadow DOM, so if changing this
         // code, be sure to run the tests in the browser before committing.
-        var shadowRoot = element.shadowRoot || element.webkitShadowRoot;
+        var shadowRoot = opt_shadowRoot || element.webkitShadowRoot;
         if (shadowRoot) {
-            axs.AuditRule.collectMatchingElements(shadowRoot,
-                                                  matcher,
-                                                  collection,
-                                                  shadowRoot);
+            axs.AuditRule.collectMatchingElementsInternal(
+              shadowRoot,
+              matcher,
+              collection,
+              shadowRoot,
+              opt_ignoreSelectors
+            );
             return;
         }
     }
@@ -158,10 +178,7 @@ axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
         var content = /** @type {HTMLContentElement} */ (element);
         var distributedNodes = content.getDistributedNodes();
         for (var i = 0; i < distributedNodes.length; i++) {
-            axs.AuditRule.collectMatchingElements(distributedNodes[i],
-                                                  matcher,
-                                                  collection,
-                                                  opt_shadowRoot);
+            axs.AuditRule.collectMatchingElementsInternal(distributedNodes[i], matcher, collection, opt_shadowRoot, opt_ignoreSelectors);
         }
         return;
     }
@@ -175,22 +192,20 @@ axs.AuditRule.collectMatchingElements = function(node, matcher, collection,
         } else {
             var distributedNodes = shadow.getDistributedNodes();
             for (var i = 0; i < distributedNodes.length; i++) {
-                axs.AuditRule.collectMatchingElements(distributedNodes[i],
-                                                      matcher,
-                                                      collection,
-                                                      opt_shadowRoot);
+                axs.AuditRule.collectMatchingElementsInternal(distributedNodes[i], matcher, collection, opt_shadowRoot, opt_ignoreSelectors);
             }
         }
     }
 
+    // If it is a iframe, get the contentDocument
+    if (element && element.localName == 'iframe' && element.contentDocument) {
+        axs.AuditRule.collectMatchingElementsInternal(element.contentDocument, matcher, collection, opt_shadowRoot, opt_ignoreSelectors);
+    }
     // If it is neither the parent of a ShadowRoot, a <content> element, nor
     // a <shadow> element recurse normally.
     var child = node.firstChild;
     while (child != null) {
-        axs.AuditRule.collectMatchingElements(child,
-                                              matcher,
-                                              collection,
-                                              opt_shadowRoot);
+        axs.AuditRule.collectMatchingElementsInternal(child, matcher, collection, opt_shadowRoot, opt_ignoreSelectors);
         child = child.nextSibling;
     }
 };
@@ -215,7 +230,7 @@ axs.AuditRule.prototype.run = function(options) {
     var maxResults = 'maxResults' in options ? options['maxResults'] : null;
 
     var relevantElements = [];
-    axs.AuditRule.collectMatchingElements(scope, this.relevantElementMatcher_, relevantElements);
+    axs.AuditRule.collectMatchingElements(scope, this.relevantElementMatcher_, relevantElements, ignoreSelectors);
 
     var failingElements = [];
 

--- a/test/audits/aria-on-reserved-element-test.js
+++ b/test/audits/aria-on-reserved-element-test.js
@@ -78,7 +78,7 @@
         var widget = fixture.appendChild(document.createElement('meta'));
         var ignoreSelectors = ['#' + (widget.id = 'ignoreMe')];
         widget.setAttribute('aria-hidden', 'false');  // global
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
+        var expected = { result: axs.constants.AuditResult.NA };
         deepEqual(rule.run({ scope: fixture, ignoreSelectors: ignoreSelectors }), expected, 'ignoreSelectors should skip this failing element');
     });
 

--- a/test/audits/aria-owns-descendant-test.js
+++ b/test/audits/aria-owns-descendant-test.js
@@ -86,7 +86,6 @@
         var result = rule.run({
             ignoreSelectors: ignoreSelectors,
             scope: fixture });
-        equal(result.result, axs.constants.AuditResult.PASS);
-        deepEqual(result.elements, []);
+        equal(result.result, axs.constants.AuditResult.NA);
     });
 })();

--- a/test/audits/multiple-aria-owners-test.js
+++ b/test/audits/multiple-aria-owners-test.js
@@ -104,7 +104,6 @@
         var result = rule.run({
             ignoreSelectors: ignoreSelectors,
             scope: fixture });
-        equal(result.result, axs.constants.AuditResult.PASS);
-        deepEqual(result.elements, []);
+        equal(result.result, axs.constants.AuditResult.NA);
     });
 })();

--- a/test/audits/non-existent-aria-related-element-test.js
+++ b/test/audits/non-existent-aria-related-element-test.js
@@ -115,6 +115,6 @@ module('NonExistentAriaRelatedElement');
         var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
         var ignoreSelectors = ['#labelledbyElement2'];
         var result = rule.run({ ignoreSelectors: ignoreSelectors, scope: fixture });
-        equal(result.result, axs.constants.AuditResult.PASS);
+        equal(result.result, axs.constants.AuditResult.NA);
     });
 });

--- a/test/js/audit-rule-test.js
+++ b/test/js/audit-rule-test.js
@@ -41,6 +41,31 @@
         equal(matched.length, DIV_COUNT);
     });
 
+    test("Simple DOM with an ignored selector", function () {
+        var container = document.getElementById('qunit-fixture');
+        container.appendChild(buildTestDom());
+        var fooElement = document.createElement('div');
+        fooElement.className = 'foo';
+        container.appendChild(fooElement);
+        var fooTest = document.createElement('div');
+        fooTest.className = 'test';
+        fooElement.appendChild(fooTest);
+        var matched = [];
+        var ignoredSelectors = ['.foo'];
+        axs.AuditRule.collectMatchingElements(container, matcher, matched, ignoredSelectors);
+        equal(matched.length, DIV_COUNT);
+    });
+
+    test("Iframe with simple DOM", function () {
+        var ifrm = document.createElement("IFRAME");
+        var container = document.getElementById('qunit-fixture');
+        container.appendChild(ifrm);
+        ifrm.contentDocument.body.appendChild(buildTestDom());
+        var matched = [];
+        axs.AuditRule.collectMatchingElements(container, matcher, matched);
+        equal(matched.length, DIV_COUNT);
+    });
+
     test("With shadow DOM with no content insertion point", function () {
         var container = document.getElementById('qunit-fixture');
         container.appendChild(buildTestDom());


### PR DESCRIPTION
Based on our reading of the README, calling 'ignoreSelectors' on a
config object with a particular selector should ignore matching nodes
and all their descendents, instead of just the nodes found by the selector.

We believe this is the correct behavior, because the README says to use
ignoreSelectors in order to 'Ignore parts of the page for a particular audit rule',
not just the element matching the selector.