### PR TITLE
Fix table audits

### DIFF
--- a/src/audits/TableHasAppropriateHeaders.js
+++ b/src/audits/TableHasAppropriateHeaders.js
@@ -88,6 +88,10 @@ goog.require('axs.constants.Severity');
                 return element.querySelectorAll('th').length != 0;
             } else {
                 var rows = element.querySelectorAll('tr');
+                if (rows.length === 0) {
+                    // table without any rows also does not have a header, etc.
+                    return true;
+                }
 
                 return tableDoesNotHaveHeaderRow(rows) &&
                     tableDoesNotHaveHeaderColumn(rows) &&

--- a/test/audits/table-has-appropriate-headers-test.js
+++ b/test/audits/table-has-appropriate-headers-test.js
@@ -304,4 +304,17 @@ module('TableHasAppropriateHeaders');
         equal(actual.result, axs.constants.AuditResult.FAIL);
         deepEqual(actual.elements, [table]);
     });
+
+    test('Table without rows', function() {
+        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+        var fixture = document.getElementById('qunit-fixture');
+
+        var table = buildTable([]);
+
+        fixture.appendChild(table);
+
+        var actual = rule.run({ scope: fixture });
+        equal(actual.result, axs.constants.AuditResult.FAIL);
+        deepEqual(actual.elements, [table]);
+    });
 })();

--- a/test/index.html
+++ b/test/index.html
@@ -79,6 +79,7 @@
     <script src="./audits/required-aria-attribute-missing-test.js"></script>
     <script src="./audits/role-tooltip-requires-described-by-test.js"></script>
     <script src="./audits/tab-index-greater-than-zero-test.js"></script>
+    <script src="./audits/table-has-appropriate-headers-test.js"></script>
     <script src="./audits/uncontrolled-tabpanel-test.js"></script>
     <script src="./audits/human-lang-missing-test.js"></script>
     <script src="./audits/unsupported-aria-attribute-test.js"></script>


### PR DESCRIPTION
This pull request fixes two things regarding table auditing:
1. The table checks never ran, they were forgotten in the QUnit HTML :warning:. This is fixed in 9095d4f.
2. The table checks failed with an `'undefined' is not an object (evaluating 'headerRow.children')` on some pages. This is due to the fact that the auditor assumes a complete table. If the markup is broken however, let's say an empty `<table></table>` without a single `<tr>` then there are no rows. This is fixed via 4f899db.
