### PR TITLE
fix: don't die in browsers that do not support shadow DOM. Fixes #255.

### DIFF
--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -154,7 +154,7 @@ axs.dom.composedTreeSearch = function(node, end, callbacks, opt_shadowRoot) {
     // If it is a <content> element, descend into distributed elements - these
     // are elements from outside the shadow root which are rendered inside the
     // shadow DOM.
-    if (element && element.localName == 'content') {
+    if (element && element.localName == 'content' && typeof element.getDistributedNodes === 'function') {
         var content = /** @type {HTMLContentElement} */ (element);
         var distributedNodes = content.getDistributedNodes();
         for (var i = 0; i < distributedNodes.length && !found; i++) {

--- a/test/js/utils-test.js
+++ b/test/js/utils-test.js
@@ -585,3 +585,35 @@ test('first fieldset legend aria-disabled', function() {
     actual = axs.utils.isElementDisabled(widget);
     strictEqual(actual, true, 'ARIA widget should be disabled');
 });
+
+test('composedTreeSearch should ignore distributed nodes if browser does not support them', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    if (fixture.createShadowRoot) {
+        var div = document.createElement('div');
+        fixture.appendChild(div);
+
+        // behave as if we don't have getDistributedNodes available in this browser
+        var r = HTMLContentElement.prototype.getDistributedNodes;
+        HTMLContentElement.prototype.getDistributedNodes = null;
+
+        var shadowroot = div.createShadowRoot();
+        shadowroot.innerHTML = '<content id="x" select="p"></content>';
+        var content = shadowroot.getElementById('x');
+
+        var found = [];
+        axs.dom.composedTreeSearch(div, null, {
+            preorder: function(e) {
+                found.push(e);
+                return true;
+            }
+        });
+
+        HTMLContentElement.prototype.getDistributedNodes = r;
+        ok(found.length === 2);
+        strictEqual(found[0], div);
+        strictEqual(found[1], content);
+    } else {
+        console.warn('Test platform does not support shadow DOM');
+        ok(true);
+    }
+});


### PR DESCRIPTION
Some browser supported don't support Shadow DOM. However the DOMUtils expect this. Fixes #255.
