### PR TITLE
fix: `isLargeFont` should not die on documents without body

### DIFF
--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -283,7 +283,7 @@ axs.utils.isLargeFont = function(style) {
     var fontSize = style.fontSize;
     var bold = style.fontWeight == 'bold';
     var matches = fontSize.match(/(\d+)px/);
-    if (matches) {
+    if (matches && document.body) {
         var fontSizePx = parseInt(matches[1], 10);
         var bodyStyle = window.getComputedStyle(document.body, null);
         var bodyFontSize = bodyStyle.fontSize;

--- a/test/js/utils-test.js
+++ b/test/js/utils-test.js
@@ -585,3 +585,11 @@ test('first fieldset legend aria-disabled', function() {
     actual = axs.utils.isElementDisabled(widget);
     strictEqual(actual, true, 'ARIA widget should be disabled');
 });
+
+module('isLargeFont');
+
+test('should check if element has a large font', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var style = window.getComputedStyle(fixture, null);
+    ok(!axs.utils.isLargeFont(style));
+});


### PR DESCRIPTION
In some rare cases `document.body` is not defined. In these cases the `isLargeFont` method dies due to 

```
TypeError: 'null' is not an object (evaluating 'window.getComputedStyle(document.body, null).fontSize')
```

This PR fixes this and adds one test for `isLargeFont` (was added to make sure there is no regression)
