### PR TITLE
fix: null access for missing referrers of aria-describedby

### DIFF
--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -1012,7 +1012,7 @@ axs.utils.getQuerySelectorText = function(obj) {
  * single ID reference.
  * @param {Element} element a potential referent.
  * @param {string=} opt_attributeName Name of an ARIA attribute to limit the results to, e.g. 'aria-owns'.
- * @return {NodeList} The elements that refer to this element.
+ * @return {NodeList} The elements that refer to this element or null.
  */
 axs.utils.getAriaIdReferrers = function(element, opt_attributeName) {
     var propertyToSelector = function(propertyKey) {

--- a/test/audits/role-tooltip-requires-described-by-test.js
+++ b/test/audits/role-tooltip-requires-described-by-test.js
@@ -91,3 +91,17 @@ test('a tooltip without an ID doesn\'t cause an exception', function() {
         ok(false, 'Running roleTooltipRequiresDescribedby threw an exception: ' + e.message);
     }
 });
+
+test('role tooltip with a corresponding describedby of a missing element id should fail', function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var tooltip = document.createElement('div');
+    var trigger = document.createElement('div');
+    fixture.appendChild(tooltip);
+    fixture.appendChild(trigger);
+    tooltip.setAttribute('role', 'tooltip');
+    trigger.setAttribute('aria-describedby', 'tooltip1');
+    deepEqual(
+        axs.AuditRules.getRule('roleTooltipRequiresDescribedby').run({ scope: fixture }),
+        { elements: [tooltip], result: axs.constants.AuditResult.FAIL }
+    );
+});


### PR DESCRIPTION
In the case of an element referred to via its ID in an `aria-describedby` and that element not existing, the function `axs.utils.getAriaIdReferrers` returns `null` which is expected by `RoleTooltipRequiresDescribedBy` to always return a `NodeList`.
This then fails with
```
TypeError: 'null' is not an object (evaluating 'axs.utils.getAriaIdReferrers(a, \"aria-describedby\").length')
```
This PR fixes this and adds a test for it.