### PR TITLE
fix: make phantom audit work with websites that expose an AMD loader

### DIFF
--- a/tools/runner/audit.js
+++ b/tools/runner/audit.js
@@ -33,6 +33,13 @@ if (system.args.length !== 2) {
         );
       phantom.exit();
     } else {
+      page.evaluate(function() {
+        // if target website has an AMD loader, we need to make sure
+        // that window.axs is still available
+        if (typeof define !== 'undefined' && define.amd) {
+            define.amd = false;
+        }
+      });
       page.injectJs('../../dist/js/axs_testing.js');
       var report = page.evaluate(function() {
         var results = axs.Audit.run();


### PR DESCRIPTION
In the case that the audited website has an exposed AMD loader, the auditor fails, because `window.axs` is undefined. This PR fixes this.