### PR TITLE
Performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### Enhancements
+
+* Performance enhancements (#263)
+* Expanded the scope of AX_ARIA_02 and rebadged it to AX_HTML_03. It now checks that elements referred to in vanilla HTML
+  are present as well as ARIA.
+
 ## 2.10.0 - 2015-11-13
 
 ## 2.10.0-rc.1 - 2015-10-19

--- a/src/audits/ControlsWithoutLabel.js
+++ b/src/audits/ControlsWithoutLabel.js
@@ -47,8 +47,8 @@ axs.AuditRules.addRule({
         }
         return true;
     },
-    test: function(control) {
-        if (axs.utils.isElementOrAncestorHidden(control))
+    test: function(control, flags) {
+        if (flags.hidden)
             return false;
         if (control.tagName.toLowerCase() == 'input' &&
             control.type == 'button' &&

--- a/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
+++ b/src/audits/FocusableElementNotVisibleAndNotAriaHidden.js
@@ -50,8 +50,8 @@ axs.AuditRules.addRule({
         return true;
 
     },
-    test: function(element) {
-        if (axs.utils.isElementOrAncestorHidden(element))
+    test: function(element, flags) {
+        if (flags.hidden)
             return false;
         element.focus();
         return !axs.utils.elementIsVisible(element);

--- a/src/audits/ImageWithoutAltText.js
+++ b/src/audits/ImageWithoutAltText.js
@@ -23,9 +23,8 @@ axs.AuditRules.addRule({
     heading: 'Images should have a text alternative or presentational role',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_02',
     severity: axs.constants.Severity.WARNING,
-    relevantElementMatcher: function(element) {
-        return axs.browserUtils.matchSelector(element, 'img') &&
-            !axs.utils.isElementOrAncestorHidden(element);
+    relevantElementMatcher: function(element, flags) {
+        return axs.browserUtils.matchSelector(element, 'img') && !flags.hidden;
     },
     test: function(image) {
         var imageIsPresentational = (image.hasAttribute('alt') && image.alt == '') || image.getAttribute('role') == 'presentation';

--- a/src/audits/LinkWithUnclearPurpose.js
+++ b/src/audits/LinkWithUnclearPurpose.js
@@ -36,7 +36,7 @@ axs.AuditRules.addRule({
      * @param {Object=} opt_config
      * @return {boolean}
      */
-    test: function(anchor, opt_config) {
+    test: function(anchor, flags, opt_config) {
         var config = opt_config || {};
         var blacklistPhrases = config['blacklistPhrases'] || [];
         var whitespaceRE = /\s+/;

--- a/src/audits/LinkWithUnclearPurpose.js
+++ b/src/audits/LinkWithUnclearPurpose.js
@@ -28,8 +28,8 @@ axs.AuditRules.addRule({
      * @param {Element} element
      * @return {boolean}
      */
-    relevantElementMatcher: function(element) {
-        return axs.browserUtils.matchSelector(element, 'a[href]') && !axs.utils.isElementOrAncestorHidden(element);
+    relevantElementMatcher: function(element, flags) {
+        return axs.browserUtils.matchSelector(element, 'a[href]') && !flags.hidden;
     },
     /**
      * @param {Element} anchor

--- a/src/audits/LowContrast.js
+++ b/src/audits/LowContrast.js
@@ -25,9 +25,8 @@ axs.AuditRules.addRule({
     heading: 'Text elements should have a reasonable contrast ratio',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_color_01',
     severity: axs.constants.Severity.WARNING,
-    relevantElementMatcher: function(element) {
-        return axs.properties.hasDirectTextDescendant(element) &&
-            !axs.utils.isElementDisabled(element);
+    relevantElementMatcher: function(element, flags) {
+        return !flags.disabled && axs.properties.hasDirectTextDescendant(element);
     },
     test: function(element) {
         var style = window.getComputedStyle(element, null);

--- a/src/audits/MeaningfulBackgroundImage.js
+++ b/src/audits/MeaningfulBackgroundImage.js
@@ -22,8 +22,8 @@ goog.require('axs.utils');
 axs.AuditRules.addRule({
     name: 'elementsWithMeaningfulBackgroundImage',
     severity: axs.constants.Severity.WARNING,
-    relevantElementMatcher: function(element) {
-        return !axs.utils.isElementOrAncestorHidden(element);
+    relevantElementMatcher: function(element, flags) {
+        return !flags.hidden;
     },
     heading: 'Meaningful images should not be used in element backgrounds',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_image_01',

--- a/src/audits/NonExistentAriaRelatedElement.js
+++ b/src/audits/NonExistentAriaRelatedElement.js
@@ -17,40 +17,27 @@ goog.require('axs.browserUtils');
 goog.require('axs.constants.Severity');
 goog.require('axs.utils');
 
-// TODO(RickSBrown): Consider expanding this beyond ARIA? e.g. 'for' on label.
-
 /**
- * 'ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM'
+ * Attributes which refer to other elements by ID should refer to elements which exist in the DOM'.
  */
 axs.AuditRules.addRule({
-    name: 'nonExistentAriaRelatedElement',
-    heading: 'ARIA attributes which refer to other elements by ID should refer to elements which exist in the DOM',
-    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_02',
+    name: 'nonExistentRelatedElement',
+    heading: 'Attributes which refer to other elements by ID should refer to elements which exist in the DOM',
+    url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_03',
     severity: axs.constants.Severity.SEVERE,
-    relevantElementMatcher: function(element) {
-        var idrefTypes = ['idref', 'idref_list'];
-        var idRefProps = axs.utils.getAriaPropertiesByValueType(idrefTypes);
-        var selector = axs.utils.getSelectorForAriaProperties(idRefProps);
-        return axs.browserUtils.matchSelector(element, selector);
+    opt_requires: {
+        idRefs: true
     },
-    test: function(element) {
-        var idrefTypes = ['idref', 'idref_list'];
-        var idRefProps = axs.utils.getAriaPropertiesByValueType(idrefTypes);
-        var selector = axs.utils.getSelectorForAriaProperties(idRefProps);
-        var selectors = selector.split(',');
-        for (var i = 0, len = selectors.length; i < len; i++) {
-            var nextSelector = selectors[i];
-            if (axs.browserUtils.matchSelector(element, nextSelector)) {
-                var propertyName = nextSelector.match(/aria-[^\]]+/)[0];
-                var propertyValueText = element.getAttribute(propertyName);
-                var propertyValue = axs.utils.getAriaPropertyValue(propertyName,
-                                                                   propertyValueText,
-                                                                   element);
-                if (!propertyValue.valid)
-                    return true;
-            }
-        }
-        return false;
+    relevantElementMatcher: function(element, flags) {
+        return flags.idrefs.length > 0;
     },
-    code: 'AX_ARIA_02'
+    test: function(element, flags) {
+        var idRefs = flags.idrefs;
+        var missing = idRefs.some(function(id) {
+            var refElement = document.getElementById(id);
+            return !refElement;
+        });
+        return missing;
+    },
+    code: 'AX_HTML_03'
 });

--- a/src/audits/RoleTooltipRequiresDescribedBy.js
+++ b/src/audits/RoleTooltipRequiresDescribedBy.js
@@ -25,9 +25,8 @@ axs.AuditRules.addRule({
     heading: 'Elements with role=tooltip should have a corresponding element with aria-describedby',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_02',
     severity: axs.constants.Severity.SEVERE,
-    relevantElementMatcher: function(element) {
-        return axs.browserUtils.matchSelector(element, '[role=tooltip]') &&
-            !axs.utils.isElementOrAncestorHidden(element);
+    relevantElementMatcher: function(element, flags) {
+        return axs.browserUtils.matchSelector(element, '[role=tooltip]') && !flags.hidden;
     },
     test: function(element) {
         return axs.utils.getAriaIdReferrers(element, 'aria-describedby').length === 0;

--- a/src/audits/UnfocusableElementsWithOnClick.js
+++ b/src/audits/UnfocusableElementsWithOnClick.js
@@ -24,12 +24,12 @@ axs.AuditRules.addRule({
     opt_requires: {
         consoleAPI: true
     },
-    relevantElementMatcher: function(element) {
+    relevantElementMatcher: function(element, flags) {
         // element.ownerDocument may not be current document if it is in an iframe
         if (element instanceof element.ownerDocument.defaultView.HTMLBodyElement) {
             return false;
         }
-        if (axs.utils.isElementOrAncestorHidden(element)) {
+        if (flags.hidden) {
             return false;
         }
         var eventListeners = getEventListeners(element);

--- a/src/audits/UnfocusableElementsWithOnClick.js
+++ b/src/audits/UnfocusableElementsWithOnClick.js
@@ -21,7 +21,9 @@ axs.AuditRules.addRule({
     heading: 'Elements with onclick handlers must be focusable',
     url: 'https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_02',
     severity: axs.constants.Severity.WARNING,
-    opt_requiresConsoleAPI: true,
+    opt_requires: {
+        consoleAPI: true
+    },
     relevantElementMatcher: function(element) {
         // element.ownerDocument may not be current document if it is in an iframe
         if (element instanceof element.ownerDocument.defaultView.HTMLBodyElement) {

--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -549,10 +549,12 @@ axs.utils.isNativelyDisableable = function(element) {
  * This element may or may not be effectively disabled in practice as this is dependent on implementation.
  *
  * @param {Element} element An element to check.
+ * @param {boolean=} ignoreAncestors If true do not check for disabled ancestors.
  * @return {boolean} true if the element or one of its ancestors is disabled.
  */
-axs.utils.isElementDisabled = function(element) {
-    if (axs.browserUtils.matchSelector(element, '[aria-disabled=true], [aria-disabled=true] *')) {
+axs.utils.isElementDisabled = function(element, ignoreAncestors) {
+    var selector = ignoreAncestors ? '[aria-disabled=true]' : '[aria-disabled=true], [aria-disabled=true] *';
+    if (axs.browserUtils.matchSelector(element, selector)) {
         return true;
     }
     if (!axs.utils.isNativelyDisableable(element) ||
@@ -560,9 +562,12 @@ axs.utils.isElementDisabled = function(element) {
         return false;
     }
     for (var next = element; next !== null; next = axs.dom.parentElement(next)) {
-        if (axs.utils.isNativelyDisableable(next) && next.hasAttribute('disabled')) {
+        if (next.hasAttribute('disabled')) {
             return true;
         }
+        if (ignoreAncestors) {
+            return false;
+    }
     }
     return false;
 };

--- a/src/js/AccessibilityUtils.js
+++ b/src/js/AccessibilityUtils.js
@@ -567,7 +567,7 @@ axs.utils.isElementDisabled = function(element, ignoreAncestors) {
         }
         if (ignoreAncestors) {
             return false;
-    }
+        }
     }
     return false;
 };
@@ -1082,6 +1082,79 @@ axs.utils.getHtmlIdReferrers = function(element) {
         return selector.replace('\{id\}', id);
     });
     return element.ownerDocument.querySelectorAll(selectors.join(','));
+};
+
+/**
+ * Gets a list of all IDs this element references in either ARIA or HTML attributes.
+ *
+ * @param {Element} element The element to check for idref attributes.
+ * @returns {Array.<string>} Any IDs this element references.
+ */
+axs.utils.getReferencedIds = function(element) {
+    var result = [];
+    var addResult = function(ids) {
+            if (ids) {
+                if (ids.indexOf(' ') > 0) {
+                    result = result.concat(attrib.value.split(' '));
+                } else {
+                    result.push(ids);
+                }
+            }
+        };
+    for (var i = 0; i < element.attributes.length; i++) {
+        var tagName = element.tagName.toLowerCase();
+        var attrib = element.attributes[i];
+        if (attrib.specified) {
+            var attribName = attrib.name;
+            var ariaAttr = attribName.match(/aria-(.+)/);
+            if (ariaAttr) {
+                var details = axs.constants.ARIA_PROPERTIES[ariaAttr[1]];
+                if (details && (details.valueType === ('idref') || details.valueType === ('idref_list'))) {
+                    addResult(attrib.value);
+                }
+                continue;
+            }
+            switch (attribName) {
+                case 'contextmenu':
+                case 'itemref':
+                    addResult(attrib.value);
+                    break;
+                case 'form':
+                    if (tagName == 'button' || tagName == 'fieldset' || tagName == 'input' ||
+                            tagName == 'keygen' || tagName == 'label' || tagName == 'object' ||
+                            tagName == 'output' || tagName == 'select' || tagName == 'textarea') {
+                        addResult(attrib.value);
+                    }
+                    break;
+                case 'for':
+                    if (tagName == 'label' || tagName == 'output') {
+                        addResult(attrib.value);
+                    }
+                    break;
+                case 'menu':
+                    if (tagName == 'button') {
+                        addResult(attrib.value);
+                    }
+                    break;
+                case 'list':
+                    if (tagName == 'input') {
+                        addResult(attrib.value);
+                    }
+                    break;
+                case 'command':
+                    if (tagName == 'menuitem') {
+                        addResult(attrib.value);
+                    }
+                    break;
+                case 'headers':
+                    if (tagName == 'td' || tagName == 'tr') {
+                        addResult(attrib.value);
+                    }
+                    break;
+            }
+        }
+    }
+    return result;
 };
 
 /**

--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -250,6 +250,11 @@ axs.Audit.run = function(opt_configuration) {
 
     var auditRules = axs.AuditRules.getActiveRules(configuration);
 
+    // As a performance optimization set the collectIdRefs flag to false if none of the rules needs it.
+    configuration.collectIdRefs = auditRules.some(function(auditRule) {
+        return auditRule.collectIdRefs;
+    });
+
     if (!configuration.scope) {
         configuration.scope = document.documentElement;
     }
@@ -281,6 +286,7 @@ goog.exportSymbol('axs.Audit.run', axs.Audit.run);
     axs.Audit.collectMatchingElements = function(configuration, auditRules) {
         var rootFlags = {
             walkDom: configuration.walkDom,
+            collectIdRefs: configuration.collectIdRefs,
             level: 0,
             ignoring: {},
             disabled: false,

--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -24,6 +24,7 @@ goog.provide('axs.AuditRule.Spec');
  * @param {axs.AuditRule.Spec} spec
  */
 axs.AuditRule = function(spec) {
+    var requires = spec.opt_requires || {};
     var isValid = true;
     var missingFields = [];
     for (var i = 0; i < axs.AuditRule.requiredFields.length; i++) {
@@ -71,32 +72,36 @@ axs.AuditRule = function(spec) {
     this.url = spec.url || '';
 
     /** @type {boolean} */
-    this.requiresConsoleAPI = !!spec['opt_requiresConsoleAPI'];
+    this.requiresConsoleAPI = !!requires.consoleAPI;
 
     /** @type {Array.<axs.AuditRule.RelevantElement>} */
     this.relevantElements = [];
 };
 
-/** @typedef {{ name: string,
+/**
+ * Note that opt_requires may have any of the following optional properties:
+ *    consoleAPI: boolean (true if the rule needs the console API)
+ *
+ * @typedef {{ name: string,
  *              heading: string,
  *              url: string,
  *              severity: axs.constants.Severity,
- *              relevantElementMatcher: function(Element): boolean,
- *              test: function(Element, Object=): boolean,
+ *              relevantElementMatcher: function(Element, Object): boolean,
+ *              test: function(Element, Object, Object=): boolean,
  *              code: string,
- *              opt_requiresConsoleAPI: boolean }} */
-axs.AuditRule.SpecWithConsoleAPI;
+ *              opt_requires: Object }} */
+axs.AuditRule.SpecWithRequires;
 
 /** @typedef {{ name: string,
  *              heading: string,
  *              url: string,
  *              severity: axs.constants.Severity,
- *              relevantElementMatcher: function(Element): boolean,
- *              test: function(Element, Object=): boolean,
+ *              relevantElementMatcher: function(Element, Object): boolean,
+ *              test: function(Element, Object, Object=): boolean,
  *              code: string }} */
-axs.AuditRule.SpecWithoutConsoleAPI;
+axs.AuditRule.SpecWithoutRequires;
 
-/** @typedef {(axs.AuditRule.SpecWithConsoleAPI|axs.AuditRule.SpecWithoutConsoleAPI)} */
+/** @typedef {(axs.AuditRule.SpecWithRequires|axs.AuditRule.SpecWithoutRequires)} */
 axs.AuditRule.Spec;
 
 /**

--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -76,10 +76,20 @@ axs.AuditRule = function(spec) {
 
     /** @type {Array.<axs.AuditRule.RelevantElement>} */
     this.relevantElements = [];
+
+    /**
+     * An audit can indicate that the DOM traversal should capture ID refs on its behalf.
+     * This is a performance enhancement which prevents multiple audits from having to call
+     * `axs.utils.getReferencedIds` on the same element during DOM traversal.
+     *
+     * @type {boolean}
+     */
+    this.collectIdRefs = requires.idRefs || false;
 };
 
 /**
  * Note that opt_requires may have any of the following optional properties:
+ *    idRefs: boolean, (true if the rule needs idRefs collected for it)
  *    consoleAPI: boolean (true if the rule needs the console API)
  *
  * @typedef {{ name: string,

--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -221,7 +221,8 @@ axs.AuditRule.prototype.run = function(configuration) {
     var next;
     while ((next = this.relevantElements.shift())) {
         var element = next.element;
-        if (this.test_(element, options.config)) {
+        var flags = next.flags;
+        if (this.test_(element, flags, options.config)) {
             result.update(axs.constants.AuditResult.FAIL, element);
         } else {
             result.update(axs.constants.AuditResult.PASS, element);

--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -47,6 +47,7 @@ axs.AuditRule = function(spec) {
     /**
      * Is this element relevant to this audit?
      * @param {Element} element A potential audit candidate.
+     * @param {Object} flags
      * @return {boolean} true if this element is relevant to this audit.
      */
     this.relevantElementMatcher_ = spec.relevantElementMatcher;
@@ -54,6 +55,7 @@ axs.AuditRule = function(spec) {
     /**
      * The actual audit function.
      * @param {Element} element The element under test.
+     * @param {Object} flags
      * @param {Object=} config
      * @return {boolean} true if this audit finds a problem.
      */
@@ -70,6 +72,9 @@ axs.AuditRule = function(spec) {
 
     /** @type {boolean} */
     this.requiresConsoleAPI = !!spec['opt_requiresConsoleAPI'];
+
+    /** @type {Array.<axs.AuditRule.RelevantElement>} */
+    this.relevantElements = [];
 };
 
 /** @typedef {{ name: string,
@@ -93,6 +98,13 @@ axs.AuditRule.SpecWithoutConsoleAPI;
 
 /** @typedef {(axs.AuditRule.SpecWithConsoleAPI|axs.AuditRule.SpecWithoutConsoleAPI)} */
 axs.AuditRule.Spec;
+
+/**
+ * When storing "relevant" or "related" elements during the DOM traversal phase
+ * also hold the flags for that element.
+ * @typedef {{element: Element, flags: Object}}
+ * */
+axs.AuditRule.RelevantElement;
 
 /**
  * @const
@@ -119,71 +131,96 @@ axs.AuditRule.prototype.addElement = function(elements, element) {
     elements.push(element);
 };
 
- /**
-  * Recursively collect elements which match |matcher| into |collection|,
-  * starting at |scope|.
-  * @param {Node} scope
-  * @param {function(Element): boolean} matcher
-  * @param {Array.<Element>} collection
-  * @param {Array.<string>=} opt_ignoreSelectors
+/**
+  * Collect elements relevant to this rule.
+  * @param {Element} element
+  * @param {Object} flags Fast lookup for various element states.
   */
-axs.AuditRule.collectMatchingElements = function(scope, matcher, collection, opt_ignoreSelectors) {
-    /**
-     * @param {!Element} element
-     * @return boolean
-     */
-    function relevantElementCollector(element) {
-        if (opt_ignoreSelectors) {
-            for (var i = 0; i < opt_ignoreSelectors.length; i++) {
-                if (axs.browserUtils.matchSelector(element, opt_ignoreSelectors[i]))
-                    return false;
-            }
-        }
-        if (matcher(element))
-            collection.push(element);
+axs.AuditRule.prototype.collectMatchingElement = function(element, flags) {
+    if (this.relevantElementMatcher_(element, flags) && flags.inScope) {
+        this.relevantElements.push({
+            element: element,
+            flags: flags
+        });
         return true;
     }
-    axs.dom.composedTreeSearch(scope, null, { preorder: relevantElementCollector });
+    return false;
 };
 
 /**
- * @param {Object} options
- *     Optional named parameters:
- *     ignoreSelectors: Selectors for parts of the page to ignore for this rule.
- *     scope: The scope in which the element selector should run.
- *         Defaults to `document`.
- *     maxResults: The maximum number of results to collect. If more than this
- *         number of results is found, 'resultsTruncated' is set to true in the
- *         returned object. If this is null or undefined, all results will be
- *         returned.
- *     config: Any per-rule configuration.
- * @return {?Object.<string, (axs.constants.AuditResult|?Array.<Element>|boolean)>}
+ * Determine if the current rule can be run based on the current configuration.
+ * @param {axs.AuditConfiguration} configuration Used to determine if this rule can run.
+ * @returns {boolean} true if the rule can run.
  */
-axs.AuditRule.prototype.run = function(options) {
-    options = options || {};
-    var scope = 'scope' in options ? options['scope'] : document;
-    var maxResults = 'maxResults' in options ? options['maxResults'] : null;
-
-    var relevantElements = [];
-    axs.AuditRule.collectMatchingElements(scope, this.relevantElementMatcher_, relevantElements, options['ignoreSelectors']);
-
-    var failingElements = [];
-
-    if (!relevantElements.length)
-        return { result: axs.constants.AuditResult.NA };
-    for (var i = 0; i < relevantElements.length; i++) {
-        if (maxResults != null && failingElements.length >= maxResults)
-            break;
-        var element = relevantElements[i];
-        if (this.test_(element, options.config))
-            this.addElement(failingElements, element);
+axs.AuditRule.prototype.canRun = function(configuration) {
+    if (this.disabled) {
+        return false;
     }
-    var result = failingElements.length ? axs.constants.AuditResult.FAIL : axs.constants.AuditResult.PASS;
-    var results = { result: result, elements: failingElements };
-    if (i < relevantElements.length)
-        results['resultsTruncated'] = true;
-
-    return results;
+    if (!configuration.withConsoleApi && this.requiresConsoleAPI) {
+        return false;
+    }
+    return true;
 };
 
-// axs.AuditRule.specs = {};
+/**
+ * Represents the result of an AuditRule.
+ * @constructor
+ */
+axs.AuditRule.Result = function(configuration, auditRule) {
+    var ruleValues = axs.utils.namedValues(auditRule);
+    ruleValues.severity = configuration.getSeverity(auditRule.name) || ruleValues.severity;
+    this.rule = ruleValues;
+    this.maxResults = configuration.maxResults;
+    this.update(axs.constants.AuditResult.NA);
+};
+
+/**
+ * Process a new audit result and update the overall state consistent with the following constraints:
+ *    NA > PASS > FAIL
+ * In other words:
+ *    NA can become PASS or FAIL
+ *    PASS can become FAIL
+ *    FAIL cannot be changed
+ * @param {axs.constants.AuditResult} auditResult The result of the current test.
+ * @param {Element=} element The element responsible for the test result, required if the result is FAIL.
+ */
+axs.AuditRule.Result.prototype.update = function(auditResult, element) {
+    var result = this;
+    if (auditResult === axs.constants.AuditResult.FAIL) {
+        var failingElements = result.elements || (result.elements = []);
+        result.result = auditResult;  // If FAIL then we change the result to FAIL no matter what it is
+        if (this.maxResults && result.elements.length >= this.maxResults) {
+            result.resultsTruncated = true;
+        } else if (element) {
+            // element should always be defined here but testing first avoids pushing undefined onto the array
+            failingElements.push(element);
+        }
+    } else if (auditResult === axs.constants.AuditResult.PASS) {
+        if (!result.elements)
+            result.elements = [];
+        if (result.result !== axs.constants.AuditResult.FAIL)
+            result.result = auditResult;  // If PASS then we change result only if it is not already FAIL
+    } else if (!result.result) {
+        result.result = auditResult;
+    }
+};
+
+/**
+ * Run this AuditRule against any relevant elements it has collected during the DOM traversal phase.
+ * @param {axs.AuditConfiguration} configuration Configuration for this run.
+ * @return {axs.AuditRule.Result}
+ */
+axs.AuditRule.prototype.run = function(configuration) {
+    var options = this._options || {};
+    var result = new axs.AuditRule.Result(configuration, this);
+    var next;
+    while ((next = this.relevantElements.shift())) {
+        var element = next.element;
+        if (this.test_(element, options.config)) {
+            result.update(axs.constants.AuditResult.FAIL, element);
+        } else {
+            result.update(axs.constants.AuditResult.PASS, element);
+        }
+    }
+    return result;
+};

--- a/src/js/AuditRules.js
+++ b/src/js/AuditRules.js
@@ -63,4 +63,27 @@ goog.provide('axs.AuditRules');
             return this.getRule(name);
         }, axs.AuditRules);
     };
+
+    /**
+     * Gets all registered audit rules which are not excluded by configuration.
+     * @param {axs.AuditConfiguration} configuration Used to determine ignored rules.
+     * @return {Array.<axs.AuditRule>}
+     */
+    axs.AuditRules.getActiveRules = function(configuration) {
+        var auditRules;
+        if (configuration.auditRulesToRun && configuration.auditRulesToRun.length > 0) {
+            auditRules = configuration.auditRulesToRun;
+        } else {
+            auditRules = axs.AuditRules.getRules(true);
+        }
+        if (configuration.auditRulesToIgnore) {
+            for (var i = 0; i < configuration.auditRulesToIgnore.length; i++) {
+                var auditRuleToIgnore = configuration.auditRulesToIgnore[i];
+                if (auditRules.indexOf(auditRuleToIgnore) < 0)
+                    continue;
+                auditRules.splice(auditRules.indexOf(auditRuleToIgnore), 1);
+            }
+        }
+        return auditRules.map(axs.AuditRules.getRule);
+    };
 })();

--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -46,7 +46,7 @@ axs.dom.shadowHost = function(fragment) {
     if ('host' in fragment)
         return fragment.host;
     else
-        return null;
+    return null;
 };
 
 /**
@@ -108,17 +108,18 @@ axs.dom.asElement = function(node) {
  * Recursively walk the composed tree from |node|, aborting if |end| is encountered.
  * @param {Node} node
  * @param {?Node} end
- * @param {{preorder: (function (Node):boolean|undefined),
- *          postorder: (function (Node)|undefined)}} callbacks
+ * @param {{preorder: (function (Node, Object):boolean|undefined),
+ *          postorder: (function (Node, Object)|undefined)}} callbacks
  *     Callbacks to be called for each element traversed, excluding
  *     |end|. Possible callbacks are |preorder|, called before descending into
  *     child nodes, and |postorder| called after all child nodes have been
  *     traversed. If |preorder| returns false, its child nodes will not be
  *     traversed.
+ * @param {Object} parentFlags
  * @param {ShadowRoot=} opt_shadowRoot The nearest ShadowRoot ancestor, if any.
  * @return {boolean} Whether |end| was found, if provided.
  */
-axs.dom.composedTreeSearch = function(node, end, callbacks, opt_shadowRoot) {
+axs.dom.composedTreeSearch = function(node, end, callbacks, parentFlags, opt_shadowRoot) {
     if (node === end)
         return true;
 
@@ -126,47 +127,53 @@ axs.dom.composedTreeSearch = function(node, end, callbacks, opt_shadowRoot) {
         var element = /** @type {Element} */ (node);
 
     var found = false;
-
-    if (element && callbacks.preorder) {
-        if (!callbacks.preorder(element))
-            return found;
-    }
+    var flags = Object.create(parentFlags);
 
     // Descend into node:
     // If it has a ShadowRoot, ignore all child elements - these will be picked
     // up by the <content> or <shadow> elements. Descend straight into the
     // ShadowRoot.
     if (element) {
+        var localName = element.localName;
+        if (callbacks.preorder) {
+            if (!callbacks.preorder(element, flags))
+                return found;
+        }
         // NOTE: grunt qunit DOES NOT support Shadow DOM, so if changing this
         // code, be sure to run the tests in the browser before committing.
         var shadowRoot = element.shadowRoot || element.webkitShadowRoot;
         if (shadowRoot) {
+            flags.level++;
             found = axs.dom.composedTreeSearch(shadowRoot,
                                                end,
                                                callbacks,
+                                               flags,
                                                shadowRoot);
             if (element && callbacks.postorder && !found)
-                callbacks.postorder(element);
+                callbacks.postorder(element, flags);
+            return found;
+        }
+
+        // If it is a <content> element, descend into distributed elements - these
+        // are elements from outside the shadow root which are rendered inside the
+        // shadow DOM.
+        if (localName == 'content') {
+            var content = /** @type {HTMLContentElement} */ (element);
+            var distributedNodes = content.getDistributedNodes();
+            for (var i = 0; i < distributedNodes.length && !found; i++) {
+                found = axs.dom.composedTreeSearch(distributedNodes[i],
+                                                       end,
+                                                       callbacks,
+                                                       flags,
+                                                       opt_shadowRoot);
+            }
+            if (callbacks.postorder && !found)
+                callbacks.postorder.call(null, element, flags);
             return found;
         }
     }
 
-    // If it is a <content> element, descend into distributed elements - these
-    // are elements from outside the shadow root which are rendered inside the
-    // shadow DOM.
-    if (element && element.localName == 'content') {
-        var content = /** @type {HTMLContentElement} */ (element);
-        var distributedNodes = content.getDistributedNodes();
-        for (var i = 0; i < distributedNodes.length && !found; i++) {
-            found = axs.dom.composedTreeSearch(distributedNodes[i],
-                                                   end,
-                                                   callbacks,
-                                                   opt_shadowRoot);
-        }
-        if (element && callbacks.postorder && !found)
-            callbacks.postorder.call(null, element);
-        return found;
-    }
+
 
     // If it is neither the parent of a ShadowRoot, a <content> element, nor
     // a <shadow> element recurse normally.
@@ -175,11 +182,12 @@ axs.dom.composedTreeSearch = function(node, end, callbacks, opt_shadowRoot) {
         found = axs.dom.composedTreeSearch(child,
                                            end,
                                            callbacks,
+                                           flags,
                                            opt_shadowRoot);
         child = child.nextSibling;
     }
 
     if (element && callbacks.postorder && !found)
-        callbacks.postorder.call(null, element);
+        callbacks.postorder.call(null, element, flags);
     return found;
 };

--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -135,6 +135,9 @@ axs.dom.composedTreeSearch = function(node, end, callbacks, parentFlags, opt_sha
     // ShadowRoot.
     if (element) {
         var localName = element.localName;
+        if (flags.collectIdRefs) {
+            flags.idrefs = axs.utils.getReferencedIds(element);
+        }
         if (!flags.disabled || (localName === 'legend') && axs.browserUtils.matchSelector(element, 'fieldset>legend:first-of-type')) {
             flags.disabled = axs.utils.isElementDisabled(element, true);
         }

--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -135,6 +135,12 @@ axs.dom.composedTreeSearch = function(node, end, callbacks, parentFlags, opt_sha
     // ShadowRoot.
     if (element) {
         var localName = element.localName;
+        if (!flags.disabled || (localName === 'legend') && axs.browserUtils.matchSelector(element, 'fieldset>legend:first-of-type')) {
+            flags.disabled = axs.utils.isElementDisabled(element, true);
+        }
+        if (!flags.hidden) {
+            flags.hidden = axs.utils.isElementHidden(element);
+        }
         if (callbacks.preorder) {
             if (!callbacks.preorder(element, flags))
                 return found;

--- a/test/audits/aria-on-reserved-element-test.js
+++ b/test/audits/aria-on-reserved-element-test.js
@@ -13,9 +13,9 @@
 // limitations under the License.
 (function() {
     module('AriaOnReservedElement');
-    var rule = axs.AuditRules.getRule('ariaOnReservedElement');
+    var RULE_NAME = 'ariaOnReservedElement';
 
-    test('Non-reserved element with role and aria- attributes', function() {
+    test('Non-reserved element with role and aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
@@ -24,27 +24,39 @@
         widget.setAttribute('aria-valuemax', '79');  // required
         widget.setAttribute('aria-valuemin', '10');  // required
         widget.setAttribute('aria-valuenow', '50');  // required
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Non-reserved elements are not applicable to this test');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config, 'Non-reserved elements are not applicable to this test');
     });
 
-    test('Non-reserved element with role only', function() {
+    test('Non-reserved element with role only', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Non-reserved elements are not applicable to this test');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config, 'Non-reserved elements are not applicable to this test');
     });
 
-    test('Non-reserved element with aria-attributes only', function() {
+    test('Non-reserved element with aria-attributes only', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('aria-hidden', 'false');  // global
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Non-reserved elements are not applicable to this test');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config, 'Non-reserved elements are not applicable to this test');
     });
 
-    test('Reserved element with role and aria- attributes', function() {
+    test('Reserved element with role and aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('meta'));
         widget.setAttribute('role', 'spinbutton');
@@ -53,40 +65,64 @@
         widget.setAttribute('aria-valuemax', '79');  // required
         widget.setAttribute('aria-valuemin', '10');  // required
         widget.setAttribute('aria-valuenow', '50');  // required
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Reserved elements can\'t take any ARIA attributes.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config, 'Reserved elements can\'t take any ARIA attributes.');
     });
 
-    test('Reserved element with role only', function() {
+    test('Reserved element with role only', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('meta'));
         widget.setAttribute('role', 'spinbutton');
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Reserved elements can\'t take any ARIA attributes.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config, 'Reserved elements can\'t take any ARIA attributes.');
     });
 
-    test('Reserved element with aria-attributes only', function() {
+    test('Reserved element with aria-attributes only', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('meta'));
         widget.setAttribute('aria-hidden', 'false');  // global
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Reserved elements can\'t take any ARIA attributes.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config, 'Reserved elements can\'t take any ARIA attributes.');
     });
 
-    test('Using ignoreSelectors, reserved element with aria-attributes only', function() {
+    test('Using ignoreSelectors, reserved element with aria-attributes only', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('meta'));
-        var ignoreSelectors = ['#' + (widget.id = 'ignoreMe')];
         widget.setAttribute('aria-hidden', 'false');  // global
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture, ignoreSelectors: ignoreSelectors }), expected, 'ignoreSelectors should skip this failing element');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA,
+            ignoreSelectors: ['#' + (widget.id = 'ignoreMe')]
+        };
+        assert.runRule(config, 'ignoreSelectors should skip this failing element');
     });
 
-    test('Reserved element with no ARIA attributes', function() {
+    test('Reserved element with no ARIA attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         fixture.appendChild(document.createElement('meta'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'A reserved element with no ARIA attributes should pass');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'A reserved element with no ARIA attributes should pass');
     });
 
 })();

--- a/test/audits/aria-owns-descendant-test.js
+++ b/test/audits/aria-owns-descendant-test.js
@@ -1,20 +1,24 @@
 (function() {  // scope to avoid leaking helpers and variables to global namespace
-    var RULE_NAME = 'ariaOwnsDescendant';
-    // TODO(RickSBrown): Refactor tests, there is too much cut and paste reuse;
     module('AriaOwnsDescendant');
 
-    test('Element owns a sibling', function() {
+    var RULE_NAME = 'ariaOwnsDescendant';
+
+    test('Element owns a sibling', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var owned = fixture.appendChild(document.createElement('div'));
         owned.id = 'ownedElement';
         var owner = fixture.appendChild(document.createElement('div'));
         owner.setAttribute('aria-owns', owned.id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element owns multiple siblings', function() {
+    test('Element owns multiple siblings', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var owned = fixture.appendChild(document.createElement('div'));
         owned.id = 'ownedElement';
@@ -22,12 +26,16 @@
         owned2.id = 'ownedElement2';
         var owner = fixture.appendChild(document.createElement('div'));
         owner.setAttribute('aria-owns', owned.id + ' ' + owned2.id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element owns a descendant', function() {
+    test('Element owns a descendant', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var owner = fixture.appendChild(document.createElement('div'));
         var owned = owner.appendChild(document.createElement('div'));
@@ -35,13 +43,16 @@
             owned = owned.appendChild(document.createElement('div'));
         owned.id = 'ownedElement';
         owner.setAttribute('aria-owns', owned.id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [owner]);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [owner]
+        };
+        assert.runRule(config);
     });
 
-    test('Element owns multiple descendants', function() {
+    test('Element owns multiple descendants', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var owner = fixture.appendChild(document.createElement('div'));
         var owned = owner.appendChild(document.createElement('div'));
@@ -51,13 +62,16 @@
         var owned2 = owner.appendChild(document.createElement('div'));
         owned2.id = 'ownedElement2';
         owner.setAttribute('aria-owns', owned.id + ' ' + owned2.id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [owner]);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [owner]
+        };
+        assert.runRule(config);
     });
 
-    test('Element owns one sibling one descendant', function() {
+    test('Element owns one sibling one descendant', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var owner = fixture.appendChild(document.createElement('div'));
         var owned = owner.appendChild(document.createElement('div'));
@@ -67,13 +81,16 @@
         var owned2 = fixture.appendChild(document.createElement('div'));
         owned2.id = 'ownedElement2';
         owner.setAttribute('aria-owns', owned.id + ' ' + owned2.id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [owner]);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [owner]
+        };
+        assert.runRule(config);
     });
 
-    test('Using ignoreSelectors - element owns a descendant', function() {
+    test('Using ignoreSelectors - element owns a descendant', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var owner = fixture.appendChild(document.createElement('div'));
         var owned = owner.appendChild(document.createElement('div'));
@@ -81,11 +98,12 @@
             owned = owned.appendChild(document.createElement('div'));
         owned.id = 'ownedElement';
         owner.setAttribute('aria-owns', owned.id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var ignoreSelectors = ['#' + (owner.id = 'ownerElement')];
-        var result = rule.run({
-            ignoreSelectors: ignoreSelectors,
-            scope: fixture });
-        equal(result.result, axs.constants.AuditResult.NA);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA,
+            ignoreSelectors: ['#' + (owner.id = 'ownerElement')]
+        };
+        assert.runRule(config, 'ignoreSelectors should skip this failing element');
     });
 })();

--- a/test/audits/aria-role-not-scoped-test.js
+++ b/test/audits/aria-role-not-scoped-test.js
@@ -13,8 +13,7 @@
 // limitations under the License.
 module('AriaRoleNotScoped');
 
-test('Scope role present', function() {
-    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+test('Scope role present', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     container.setAttribute('role', 'list');
@@ -23,16 +22,18 @@ test('Scope role present', function() {
         item.setAttribute('role', 'listitem');
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        ruleName: 'ariaRoleNotScoped',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Scope role implicitly present', function() {
+test('Scope role implicitly present', function(assert) {
     /*
      * The HTML + ARIA here is not necessarily good - it is built to facilitate testing, nothing else.
      */
-    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('ol'));
     for (var i = 0; i < 4; i++) {
@@ -40,13 +41,15 @@ test('Scope role implicitly present', function() {
         item.setAttribute('role', 'listitem');
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        ruleName: 'ariaRoleNotScoped',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Scope role present via aria-owns', function() {
-    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+test('Scope role present via aria-owns', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     var siblingContainer = fixture.appendChild(document.createElement('div'));
@@ -59,14 +62,17 @@ test('Scope role present via aria-owns', function() {
         item.setAttribute('id', id);
     }
     container.setAttribute('aria-owns', ids.join(' '));
-    var actual = rule.run({ scope: fixture });
     equal(container.childNodes.length, 0, 'container should have no child nodes since we\'re checking use of aria-owns');  // paranoid check to ensure the test itself is correct
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+
+    var config = {
+        ruleName: 'ariaRoleNotScoped',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Scope role missing', function() {
-    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+test('Scope role missing', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var expected = [];
     for (var i = 0; i < 4; i++) {
@@ -75,13 +81,15 @@ test('Scope role missing', function() {
         expected.push(item);
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, expected);
+    var config = {
+        ruleName: 'ariaRoleNotScoped',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: expected
+    };
+    assert.runRule(config);
 });
 
-test('Scope role present - tablist', function() {
-    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+test('Scope role present - tablist', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('ul'));
     container.setAttribute('role', 'tablist');
@@ -90,13 +98,15 @@ test('Scope role present - tablist', function() {
         item.setAttribute('role', 'tab');
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        ruleName: 'ariaRoleNotScoped',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Scope role missing - tab', function() {
-    var rule = axs.AuditRules.getRule('ariaRoleNotScoped');
+test('Scope role missing - tab', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('ul'));
     var expected = [];
@@ -106,7 +116,10 @@ test('Scope role missing - tab', function() {
         expected.push(item);
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, expected);
+    var config = {
+        ruleName: 'ariaRoleNotScoped',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: expected
+    };
+    assert.runRule(config);
 });

--- a/test/audits/bad-aria-attribute-test.js
+++ b/test/audits/bad-aria-attribute-test.js
@@ -13,9 +13,9 @@
 // limitations under the License.
 (function() {
     module('BadAriaAttribute');
-    var rule = axs.AuditRules.getRule('badAriaAttribute');
+    var RULE_NAME = 'badAriaAttribute';
 
-    test('Element with role and global, supported and required attributes', function() {
+    test('Element with role and global, supported and required attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
@@ -24,26 +24,36 @@
         widget.setAttribute('aria-valuemax', '79');  // required
         widget.setAttribute('aria-valuemin', '10');  // required
         widget.setAttribute('aria-valuenow', '50');  // required
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Test should pass with global, supported and required attributes for role');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'Test should pass with global, supported and required attributes for role');
     });
 
     /*
      * This rule shouldn't care if required and/or supported roles are missing.
      */
-    test('Element with role and global but missing supported and required attributes', function() {
+    test('Element with role and global but missing supported and required attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-hidden', 'false');  // global (so the audit will encounter this element)
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule shouldn\'t care if required and/or supported roles are missing.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'This rule shouldn\'t care if required and/or supported roles are missing.');
     });
 
     /*
      * This rule shouldn't care if known ARIA attributes are used with the wrong role.
      */
-    test('Element with role and known but unsupported attributes', function() {
+    test('Element with role and known but unsupported attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'group');
@@ -51,23 +61,33 @@
         widget.setAttribute('aria-valuemax', '79');  // unsupported
         widget.setAttribute('aria-valuemin', '10');  // unsupported
         widget.setAttribute('aria-valuenow', '50');  // unsupported
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule shouldn\'t care if known ARIA attributes are used with the wrong role.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'This rule shouldn\'t care if known ARIA attributes are used with the wrong role.');
     });
 
     /*
      * This rule shouldn't care if we put ARIA attributes on elements that shouldn't have them.
      */
-    test('Element with role and global but missing supported and required attributes', function() {
+    test('Element with role and global but missing supported and required attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('meta'));  // note, a reserved HTML element
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-hidden', 'false');  // global (so the audit will encounter this element)
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule shouldn\'t care if we put ARIA attributes on elements that shouldn\'t have them.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'This rule shouldn\'t care if we put ARIA attributes on elements that shouldn\'t have them.');
     });
 
-    test('Element with a role and unknown aria- attribute', function() {
+    test('Element with a role and unknown aria- attribute', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
@@ -77,41 +97,60 @@
         widget.setAttribute('aria-valuemax', '79');  // required
         widget.setAttribute('aria-valuemin', '10');  // required
         widget.setAttribute('aria-valuenow', '50');  // required
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule should detect unknown "aria-" attributes on elements with role');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config, 'This rule should detect unknown "aria-" attributes on elements with role');
     });
 
     /*
      * This rule definitely needs to visit elements with no role attribute.
      */
-    test('Element with no role and unknown aria- attribute', function() {
+    test('Element with no role and unknown aria- attribute', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('aria-bananapeel', 'oops');  // unknown
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule should detect unknown "aria-" attributes on elements without role');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config, 'This rule should detect unknown "aria-" attributes on elements without role');
     });
 
     /*
      * This rule can ignore elements with no aria- attributes.
      */
-    test('Element with role but no aria- attributes', function() {
+    test('Element with role but no aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule should ignore elements with no aria- attributes.');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config, 'This rule should ignore elements with no aria- attributes.');
     });
 
-    test('Element with no role and some known, some unknown aria- attributes', function() {
+    test('Element with no role and some known, some unknown aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('aria-busy', 'false');  // global
         widget.setAttribute('aria-hidden', 'false');  // global
         widget.setAttribute('aria-awards', 'true');  // unknown
         widget.setAttribute('aria-singer', 'true');  // unknown
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'This rule should detect unknown "aria-" attributes amongst known ones');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config, 'This rule should detect unknown "aria-" attributes amongst known ones');
     });
 
 })();

--- a/test/audits/bad-aria-attribute-value-test.js
+++ b/test/audits/bad-aria-attribute-value-test.js
@@ -1,56 +1,66 @@
 module('BadAriaAttributeValue');
 
-test('Empty idref value is ok', function() {
+test('Empty idref value is ok', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var div = document.createElement('div');
     fixture.appendChild(div);
     div.setAttribute('aria-activedescendant', '');
-    deepEqual(
-      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
-      { elements: [], result: axs.constants.AuditResult.PASS }
-    );
+    var config = {
+        ruleName: 'badAriaAttributeValue',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Bad number value doesn\'t cause crash', function() {
+test('Bad number value doesn\'t cause crash', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var div = document.createElement('div');
     fixture.appendChild(div);
     div.setAttribute('aria-valuenow', 'foo');
-    deepEqual(
-      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
-      { elements: [div], result: axs.constants.AuditResult.FAIL }
-    );
+    var config = {
+        ruleName: 'badAriaAttributeValue',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [div]
+    };
+    assert.runRule(config);
 });
 
-test('Good number value is good', function() {
+test('Good number value is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var div = document.createElement('div');
     fixture.appendChild(div);
     div.setAttribute('aria-valuenow', '10');
-    deepEqual(
-      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
-      { elements: [], result: axs.constants.AuditResult.PASS }
-    );
+    var config = {
+        ruleName: 'badAriaAttributeValue',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Good decimal number value is good', function() {
+test('Good decimal number value is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var div = document.createElement('div');
     fixture.appendChild(div);
     div.setAttribute('aria-valuenow', '0.5');
-    deepEqual(
-      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
-      { elements: [], result: axs.constants.AuditResult.PASS }
-    );
+    var config = {
+        ruleName: 'badAriaAttributeValue',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Good negative number value is good', function() {
+test('Good negative number value is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var div = document.createElement('div');
     fixture.appendChild(div);
     div.setAttribute('aria-valuenow', '-10');
-    deepEqual(
-      axs.AuditRules.getRule('badAriaAttributeValue').run({ scope: fixture }),
-      { elements: [], result: axs.constants.AuditResult.PASS }
-    );
+    var config = {
+        ruleName: 'badAriaAttributeValue',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });

--- a/test/audits/bad-aria-role-test.js
+++ b/test/audits/bad-aria-role-test.js
@@ -1,27 +1,27 @@
 module('BadAriaRole');
 
-test('No elements === no problems.', function() {
-  // Setup fixture
-  var fixture = document.getElementById('qunit-fixture');
-  deepEqual(
-    axs.AuditRules.getRule('badAriaRole').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA }
-  );
+test('No elements === no problems.', function(assert) {
+    var config = {
+        ruleName: 'badAriaRole',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('No roles === no problems.', function() {
+test('No roles === no problems.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   for (var i = 0; i < 10; i++)
     fixture.appendChild(document.createElement('div'));
 
-  deepEqual(
-    axs.AuditRules.getRule('badAriaRole').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA }
-  );
+    var config = {
+        ruleName: 'badAriaRole',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('Good role === no problems.', function() {
+test('Good role === no problems.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   for (var r in axs.constants.ARIA_ROLES) {
@@ -32,33 +32,40 @@ test('Good role === no problems.', function() {
     }
   }
 
-  deepEqual(
-    axs.AuditRules.getRule('badAriaRole').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+    var config = {
+        ruleName: 'badAriaRole',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Bad role == problem', function() {
+test('Bad role == problem', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('role', 'not-an-aria-role');
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('badAriaRole').run({ scope: fixture }),
-    { elements: [div], result: axs.constants.AuditResult.FAIL }
-  );
 
+    var config = {
+        ruleName: 'badAriaRole',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [div]
+    };
+    assert.runRule(config);
 });
 
-test('Abstract role == problem', function() {
+test('Abstract role == problem', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('role', 'input');
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('badAriaRole').run({ scope: fixture }),
-    { elements: [div], result: axs.constants.AuditResult.FAIL }
-  );
+
+    var config = {
+        ruleName: 'badAriaRole',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [div]
+    };
+    assert.runRule(config);
 });

--- a/test/audits/controls-without-label-test.js
+++ b/test/audits/controls-without-label-test.js
@@ -1,6 +1,6 @@
 module('ControlsWithoutLabel');
 
-test('Button with type="submit" or type="reset" has label', function() {
+test('Button with type="submit" or type="reset" has label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -11,12 +11,15 @@ test('Button with type="submit" or type="reset" has label', function() {
     resetInput.type = 'reset';
     fixture.appendChild(resetInput);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    equal(rule.run({scope: fixture}).result,
-          axs.constants.AuditResult.PASS);
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Button element with inner text needs no label', function() {
+test('Button element with inner text needs no label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -24,12 +27,15 @@ test('Button element with inner text needs no label', function() {
     button.textContent = 'Click me!';
     fixture.appendChild(button);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    equal(rule.run({ scope: fixture }).result,
-          axs.constants.AuditResult.PASS);
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Button element with empty inner text does need a label', function() {
+test('Button element with empty inner text does need a label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -37,12 +43,14 @@ test('Button element with empty inner text does need a label', function() {
     button.innerHTML = '<span></span>';
     fixture.appendChild(button);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    equal(rule.run({ scope: fixture }).result,
-          axs.constants.AuditResult.FAIL);
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.FAIL
+    };
+    assert.runRule(config);
 });
 
-test('Input type button with value needs no label', function() {
+test('Input type button with value needs no label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -51,12 +59,15 @@ test('Input type button with value needs no label', function() {
     input.value = 'Click me!';
     fixture.appendChild(input);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    equal(rule.run({ scope: fixture }).result,
-          axs.constants.AuditResult.PASS);
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Input with role="presentation" needs no label', function() {
+test('Input with role="presentation" needs no label', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
 
     var input = document.createElement('input');
@@ -72,12 +83,14 @@ test('Input with role="presentation" needs no label', function() {
       fixture.appendChild(control);
     });
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    equal(rule.run({ scope: fixture }).result,
-          axs.constants.AuditResult.NA);
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('Button element with image with alt needs no label', function() {
+test('Button element with image with alt needs no label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -86,12 +99,15 @@ test('Button element with image with alt needs no label', function() {
     img.setAttribute("alt", "Save");
     fixture.appendChild(button);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    equal(rule.run({ scope: fixture }).result,
-          axs.constants.AuditResult.PASS);
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Button element with image with empty alt needs a label', function() {
+test('Button element with image with empty alt needs a label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -100,12 +116,15 @@ test('Button element with image with empty alt needs a label', function() {
     img.setAttribute("alt", "");
     fixture.appendChild(button);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    deepEqual(rule.run({ scope: fixture }),
-        { elements: [button], result: axs.constants.AuditResult.FAIL });
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [button]
+    };
+    assert.runRule(config);
 });
 
-test('Button element with image with no alt needs a label', function() {
+test('Button element with image with no alt needs a label', function(assert) {
     // Setup fixture
     var fixture = document.getElementById('qunit-fixture');
 
@@ -113,49 +132,58 @@ test('Button element with image with no alt needs a label', function() {
     button.appendChild(document.createElement('img'));
     fixture.appendChild(button);
 
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
-    deepEqual(rule.run({ scope: fixture }),
-        { elements: [button], result: axs.constants.AuditResult.FAIL });
+    var config = {
+        ruleName: 'controlsWithoutLabel',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [button]
+    };
+    assert.runRule(config);
 });
 
-(function(){
-    var rule = axs.AuditRules.getRule('controlsWithoutLabel');
+(function() {
     var needLabel = ['checkbox', 'email', 'file', 'number', 'password', 'radio', 'range', 'tel', 'text', 'time', 'url'];
 
-    test('Input types which need a label - missing label', function() {
+    test('Input types which need a label - missing label', function(assert) {
         needLabel.forEach(function (type) {
             var input = document.createElement('input');
             input.setAttribute("type", type);
             var fixture = document.getElementById('qunit-fixture');
             fixture.appendChild(input);
             try {
-                deepEqual(rule.run({ scope: fixture }),
-                    { elements: [input], result: axs.constants.AuditResult.FAIL });
-            }
-            finally {
+                var config = {
+                    ruleName: 'controlsWithoutLabel',
+                    expected: axs.constants.AuditResult.FAIL,
+                    elements: [input]
+                };
+                assert.runRule(config);
+            } finally {
                 fixture.removeChild(input);
             }
         });
     });
 
-    test('Input types which need a label - ARIA label', function() {
-        needLabel.forEach(function (type) {
+    test('Input types which need a label - ARIA label', function(assert) {
+        needLabel.forEach(function(type) {
             var input = document.createElement('input');
             input.setAttribute("type", type);
             input.setAttribute("aria-label", "What is the answer?");
             var fixture = document.getElementById('qunit-fixture');
             fixture.appendChild(input);
             try {
-                equal(rule.run({ scope: fixture }).result, axs.constants.AuditResult.PASS);
-            }
-            finally {
+                var config = {
+                    ruleName: 'controlsWithoutLabel',
+                    expected: axs.constants.AuditResult.PASS,
+                    elements: []
+                };
+                assert.runRule(config);
+            } finally {
                 fixture.removeChild(input);
             }
         });
     });
 
-    test('Input types which need a label - ARIA labelledby', function() {
-        needLabel.forEach(function (type) {
+    test('Input types which need a label - ARIA labelledby', function(assert) {
+        needLabel.forEach(function(type) {
             var input = document.createElement('input');
             input.setAttribute("type", type);
             var id = goog.getUid(input);
@@ -168,17 +196,21 @@ test('Button element with image with no alt needs a label', function() {
             fixture.appendChild(label);
             fixture.appendChild(input);
             try {
-                equal(rule.run({ scope: fixture }).result, axs.constants.AuditResult.PASS);
-            }
-            finally {
+                var config = {
+                    ruleName: 'controlsWithoutLabel',
+                    expected: axs.constants.AuditResult.PASS,
+                    elements: []
+                };
+                assert.runRule(config);
+            } finally {
                 fixture.removeChild(input);
                 fixture.removeChild(label);
             }
         });
     });
 
-    test('Input types which need a label - HTML label', function() {
-        needLabel.forEach(function (type) {
+    test('Input types which need a label - HTML label', function(assert) {
+        needLabel.forEach(function(type) {
             var input = document.createElement('input');
             input.setAttribute("type", type);
             var id = goog.getUid(input);
@@ -191,9 +223,13 @@ test('Button element with image with no alt needs a label', function() {
             fixture.appendChild(label);
             fixture.appendChild(input);
             try {
-                equal(rule.run({ scope: fixture }).result, axs.constants.AuditResult.PASS);
-            }
-            finally {
+                var config = {
+                    ruleName: 'controlsWithoutLabel',
+                    expected: axs.constants.AuditResult.PASS,
+                    elements: []
+                };
+                assert.runRule(config);
+            } finally {
                 fixture.removeChild(input);
                 fixture.removeChild(label);
             }

--- a/test/audits/duplicate-id-test.js
+++ b/test/audits/duplicate-id-test.js
@@ -13,8 +13,7 @@
 // limitations under the License.
 module('DuplicateId');
 
-test('No duplicate ID, no used IDREF', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('No duplicate ID, no used IDREF', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
 
     var element = fixture.appendChild(document.createElement('div'));
@@ -23,12 +22,15 @@ test('No duplicate ID, no used IDREF', function() {
     var element2 = fixture.appendChild(document.createElement('div'));
     element2.setAttribute('id', 'fukung');
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('No duplicate ID with IDREF', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('No duplicate ID with IDREF', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
 
     var element = fixture.appendChild(document.createElement('input'));
@@ -38,26 +40,32 @@ test('No duplicate ID with IDREF', function() {
     fixture.appendChild(document.createElement('label')).setAttribute('for', element.id);
     fixture.appendChild(document.createElement('label')).setAttribute('for', element2.id);
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Single duplicate ID, not used', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('Single duplicate ID, not used', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
 
     var element = fixture.appendChild(document.createElement('div'));
     element.setAttribute('id', 'kungfu');
     fixture.appendChild(element.cloneNode());
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('Single unused duplicate ID but it\'s in shadow DOM', function() {
+test('Single unused duplicate ID but it\'s in shadow DOM', function(assert) {
     // Perhaps this test is overly paranoid...
-    var rule = axs.AuditRules.getRule('duplicateId');
     var fixture = document.getElementById('qunit-fixture');
     if (!fixture.createShadowRoot) {
         expect(0);  // even Chrome (36 on Mac) seems to end up here...
@@ -71,12 +79,15 @@ test('Single unused duplicate ID but it\'s in shadow DOM', function() {
     var shadowRoot = element2.createShadowRoot();
     shadowRoot.appendChild(element.cloneNode());
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('Single used duplicate ID but it\'s in shadow DOM', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('Single used duplicate ID but it\'s in shadow DOM', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     if (!fixture.createShadowRoot) {
         expect(0);  // even Chrome (36 on Mac) seems to end up here...
@@ -93,12 +104,17 @@ test('Single used duplicate ID but it\'s in shadow DOM', function() {
     var shadowRoot = element2.createShadowRoot();
     shadowRoot.appendChild(element.cloneNode());
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+
+    assert.runRule(config);
 });
 
-test('Single duplicate ID, used in html idref', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('Single duplicate ID, used in html idref', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
 
     var element = fixture.appendChild(document.createElement('input'));
@@ -107,23 +123,31 @@ test('Single duplicate ID, used in html idref', function() {
     var referrer = fixture.appendChild(document.createElement('label'));
     referrer.setAttribute('for', element.id);
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, [element, element2]);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [element, element2]
+    };
+
+    assert.runRule(config);
+
+    config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
 
     referrer.setAttribute('aria-hidden', 'true');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'aria-hidden elements should be ignored');
+    assert.runRule(config, 'aria-hidden elements should be ignored');
+
     referrer.removeAttribute('aria-hidden');
 
     referrer.setAttribute('hidden', 'hidden');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'hidden elements should be ignored');
-
+    assert.runRule(config, 'hidden elements should be ignored');
 });
 
-test('Single duplicate ID, used in html idrefs', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('Single duplicate ID, used in html idrefs', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
 
     var element = fixture.appendChild(document.createElement('input'));
@@ -135,22 +159,31 @@ test('Single duplicate ID, used in html idrefs', function() {
     var referrer = fixture.appendChild(document.createElement('output'));
     referrer.setAttribute('for', idrefs);
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, [element, element2]);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [element, element2]
+    };
+
+    assert.runRule(config);
+
+    config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
 
     referrer.setAttribute('aria-hidden', 'true');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'aria-hidden elements should be ignored');
+    assert.runRule(config, 'aria-hidden elements should be ignored');
+
     referrer.removeAttribute('aria-hidden');
 
     referrer.setAttribute('hidden', 'hidden');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'hidden elements should be ignored');
+    assert.runRule(config, 'hidden elements should be ignored');
 });
 
-test('Single duplicate ID, used in ARIA idref', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('Single duplicate ID, used in ARIA idref', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     var element = container.appendChild(document.createElement('span'));
@@ -158,23 +191,31 @@ test('Single duplicate ID, used in ARIA idref', function() {
     var element2 = container.appendChild(element.cloneNode());
     container.setAttribute('aria-activedescendant', element.id);
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, [element, element2]);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [element, element2]
+    };
+
+    assert.runRule(config);
+
+    config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
 
     container.setAttribute('aria-hidden', 'true');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'aria-hidden elements should be ignored');
+    assert.runRule(config, 'aria-hidden elements should be ignored');
+
     container.removeAttribute('aria-hidden');
 
     container.setAttribute('hidden', 'hidden');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'hidden elements should be ignored');
-
+    assert.runRule(config, 'hidden elements should be ignored');
 });
 
-test('Single duplicate ID, used in ARIA idrefs', function() {
-    var rule = axs.AuditRules.getRule('duplicateId');
+test('Single duplicate ID, used in ARIA idrefs', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     var element = fixture.appendChild(document.createElement('span'));
@@ -185,16 +226,26 @@ test('Single duplicate ID, used in ARIA idrefs', function() {
     var idrefs = element3.id + ' ' + element.id;
     container.setAttribute('aria-owns', idrefs);
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, [element, element2]);
+    var config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [element, element2]
+    };
+
+    assert.runRule(config);
+
+    config = {
+        scope: fixture,
+        ruleName: 'duplicateId',
+        expected: axs.constants.AuditResult.NA
+    };
 
     container.setAttribute('aria-hidden', 'true');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'aria-hidden elements should be ignored');
+    assert.runRule(config, 'aria-hidden elements should be ignored');
+
     container.removeAttribute('aria-hidden');
 
     container.setAttribute('hidden', 'hidden');
-    actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA, 'hidden elements should be ignored');
+    assert.runRule(config, 'hidden elements should be ignored');
 });

--- a/test/audits/focusable-element-not-visible-not-aria-hidden-test-browser.js
+++ b/test/audits/focusable-element-not-visible-not-aria-hidden-test-browser.js
@@ -27,7 +27,7 @@ module('FocusableElementNotVisibleAndNotAriaHiddenBrowser', {
   }
 });
 
-test('a focusable element that is hidden but shown on focus passes the audit', function() {
+test('a focusable element that is hidden but shown on focus passes the audit', function(assert) {
   var style = document.createElement('style');
   var skipLink = document.createElement('a');
 
@@ -40,25 +40,32 @@ test('a focusable element that is hidden but shown on focus passes the audit', f
   this.fixture_.appendChild(style);
   this.fixture_.appendChild(skipLink);
 
-  var rule = axs.AuditRules.getRule('focusableElementNotVisibleAndNotAriaHidden');
-  deepEqual(
-    rule.run({scope: this.fixture_}),
-    { elements: [], result: axs.constants.AuditResult.PASS });
+  var config = {
+    scope: this.fixture_,
+    ruleName: 'focusableElementNotVisibleAndNotAriaHidden',
+    expected: axs.constants.AuditResult.PASS,
+    elements: []
+  };
+  assert.runRule(config);
 });
 
-test('a focusable element inside of Shadow DOM is not "obscured" by the shadow host', function() {
+test('a focusable element inside of Shadow DOM is not "obscured" by the shadow host', function(assert) {
   var host = this.fixture_.appendChild(document.createElement("div"));
-  host.id = 'host';
+    host.id = 'host';
   if (host.createShadowRoot) {
     var root = host.createShadowRoot();
     var shadowLink = root.appendChild(document.createElement('a'));
     shadowLink.href = '#main';
     shadowLink.id = 'shadowLink';
     shadowLink.textContent = 'Skip to content';
-    var rule = axs.AuditRules.getRule('focusableElementNotVisibleAndNotAriaHidden');
-    deepEqual(
-      rule.run({scope: this.fixture_}),
-      { elements: [], result: axs.constants.AuditResult.PASS });
+
+    var config = {
+      scope: this.fixture_,
+      ruleName: 'focusableElementNotVisibleAndNotAriaHidden',
+      expected: axs.constants.AuditResult.PASS,
+      elements: []
+    };
+    assert.runRule(config);
     deepEqual(axs.utils.overlappingElements(shadowLink), []);
   } else {
     console.warn("Test platform does not support shadow DOM");

--- a/test/audits/focusable-element-not-visible-not-aria-hidden-test.js
+++ b/test/audits/focusable-element-not-visible-not-aria-hidden-test.js
@@ -23,38 +23,45 @@ module('FocusableElementNotVisibleAndNotAriaHidden', {
   }
 });
 
-test('a focusable element that is visible passes the audit', function() {
+test('a focusable element that is visible passes the audit', function(assert) {
   var input = document.createElement('input');
 
   this.fixture_.appendChild(input);
-  var rule = axs.AuditRules.getRule('focusableElementNotVisibleAndNotAriaHidden');
-  deepEqual(
-    rule.run({scope: this.fixture_}),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+
+    var config = {
+        scope: this.fixture_,
+        ruleName: 'focusableElementNotVisibleAndNotAriaHidden',
+        elements: [],
+        expected: axs.constants.AuditResult.PASS
+    };
+    assert.runRule(config);
 });
 
-test('a focusable element that is hidden fails the audit', function() {
+test('a focusable element that is hidden fails the audit', function(assert) {
   var input = document.createElement('input');
   input.style.opacity = '0';
 
   this.fixture_.appendChild(input);
 
-  var rule = axs.AuditRules.getRule('focusableElementNotVisibleAndNotAriaHidden');
-  deepEqual(
-    rule.run({scope: this.fixture_}),
-    { elements: [input], result: axs.constants.AuditResult.FAIL }
-  );
+    var config = {
+        scope: this.fixture_,
+        ruleName: 'focusableElementNotVisibleAndNotAriaHidden',
+        elements: [input],
+        expected: axs.constants.AuditResult.FAIL
+    };
+    assert.runRule(config);
 });
 
-test('an element with negative tabindex and empty computed text is ignored', function() {
+test('an element with negative tabindex and empty computed text is ignored', function(assert) {
   var emptyDiv = document.createElement('div');
   emptyDiv.tabIndex = '-1';
   this.fixture_.appendChild(emptyDiv);
 
-  var rule = axs.AuditRules.getRule('focusableElementNotVisibleAndNotAriaHidden');
-  deepEqual(
-    rule.run({scope: this.fixture_}),
-    { result: axs.constants.AuditResult.NA });
+    var config = {
+        scope: this.fixture_,
+        ruleName: 'focusableElementNotVisibleAndNotAriaHidden',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 

--- a/test/audits/human-lang-missing-test.js
+++ b/test/audits/human-lang-missing-test.js
@@ -1,7 +1,12 @@
 module("Human lang");
 
-test("Test lang attribute must be present", function() {
-    var rule = axs.AuditRules.getRule('humanLangMissing');
+test('Test lang attribute must be present', function(assert) {
+
+    var config = {
+        scope: document.documentElement,
+        ruleName: 'humanLangMissing',
+        expected: axs.constants.AuditResult.FAIL
+    };
 
     // Remove the humanLang attribute from the qunit test page.
     var htmlElement = document.querySelector('html');
@@ -9,13 +14,11 @@ test("Test lang attribute must be present", function() {
     var htmlLang = htmlElement.lang;
     htmlElement.lang = '';
 
-    equal(rule.run().result, 
-        axs.constants.AuditResult.FAIL);
 
     htmlElement.lang = 'en-US';
 
-    equal(rule.run().result, 
-        axs.constants.AuditResult.PASS);
+    config.expected = axs.constants.AuditResult.PASS;
+    assert.runRule(config);
 
     htmlElement.lang = htmlLang;
 });

--- a/test/audits/image-without-alt-text-test.js
+++ b/test/audits/image-without-alt-text-test.js
@@ -14,53 +14,78 @@
 
 (function() {
     module('ImageWithoutAltText');
-    var rule = axs.AuditRules.getRule('imagesWithoutAltText');
+    var RULE_NAME = 'imagesWithoutAltText';
 
-    test('Image with no text alternative', function() {
+    test('Image with no text alternative', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
-        var expected = { elements: [img], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has no text alternative');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [img],
+            expected: axs.constants.AuditResult.FAIL
+        };
+        assert.runRule(config, 'Image has no text alternative');
     });
 
-    test('Image with no text alternative and presentational role', function() {
+    test('Image with no text alternative and presentational role', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
         img.setAttribute('role', 'presentation');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has presentational role');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [],
+            expected: axs.constants.AuditResult.PASS
+        };
+        assert.runRule(config, 'Image has presentational role');
     });
 
-    test('Image with alt text', function() {
+    test('Image with alt text', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
         img.alt = 'Smile!';
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has alt text');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [],
+            expected: axs.constants.AuditResult.PASS
+        };
+        assert.runRule(config, 'Image has alt text');
     });
 
-    test('Image with empty alt text', function() {
+    test('Image with empty alt text', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
         img.alt = '';
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has empty alt text');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [],
+            expected: axs.constants.AuditResult.PASS
+        };
+        assert.runRule(config, 'Image has empty alt text');
     });
 
-    test('Image with aria label', function() {
+    test('Image with aria label', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
         img.setAttribute('aria-label', 'Smile!');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has aria label');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [],
+            expected: axs.constants.AuditResult.PASS
+        };
+        assert.runRule(config, 'Image has aria label');
     });
 
-    test('Image with aria labelledby', function() {
+    test('Image with aria labelledby', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
@@ -68,16 +93,26 @@
         label.textContent = 'Smile!';
         label.id = 'label';
         img.setAttribute('aria-labelledby', 'label');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has aria labelledby');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [],
+            expected: axs.constants.AuditResult.PASS
+        };
+        assert.runRule(config, 'Image has aria labelledby');
     });
 
-    test('Image with title', function() {
+    test('Image with title', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var img = fixture.appendChild(document.createElement('img'));
         img.src = 'smile.jpg';
         img.setAttribute('title', 'Smile!');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'Image has title');
+
+        var config = {
+            ruleName: RULE_NAME,
+            elements: [],
+            expected: axs.constants.AuditResult.PASS
+        };
+        assert.runRule(config, 'Image has title');
     });
 })();

--- a/test/audits/link-with-unclear-purpose.js
+++ b/test/audits/link-with-unclear-purpose.js
@@ -14,47 +14,54 @@
 
 module('LinkWithUnclearPurpose');
 
-test('a link with meaningful text is good', function() {
+test('a link with meaningful text is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var a = fixture.appendChild(document.createElement('a'));
     a.href = '#main';
     a.textContent = 'Learn more about trout fishing';
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-        rule.run({scope: fixture}),
-        { elements: [], result: axs.constants.AuditResult.PASS });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [],
+        expected: axs.constants.AuditResult.PASS
+    };
+    assert.runRule(config);
 });
 
-test('a link with an img with meaningful alt text is good', function() {
+test('a link with an img with meaningful alt text is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var a = fixture.appendChild(document.createElement('a'));
     a.href = '#main';
     var img = a.appendChild(document.createElement('img'));
     img.setAttribute('alt', 'Learn more about trout fishing');
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-        rule.run({scope: fixture}),
-        { elements: [], result: axs.constants.AuditResult.PASS });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [],
+        expected: axs.constants.AuditResult.PASS
+    };
+    assert.runRule(config);
 });
 
-test('a link with an img with meaningless alt text is bad', function() {
+test('a link with an img with meaningless alt text is bad', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var a = fixture.appendChild(document.createElement('a'));
     a.href = '#main';
     var img = a.appendChild(document.createElement('img'));
     img.setAttribute('alt', 'Click here!');
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(rule.run({scope: fixture}),
-        { elements: [a], result: axs.constants.AuditResult.FAIL });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [a],
+        expected: axs.constants.AuditResult.FAIL
+    };
+    assert.runRule(config);
 });
 
 /*
  * This test will need to be reviewed when issue #214 is addressed.
  */
-test('a link with meaningful aria-label is good', function() {
+test('a link with meaningful aria-label is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     // Style our link to be visually meaningful with no descendent nodes at all.
     fixture.innerHTML = '<style>a.trout::after{content: "Learn more about trout fishing"}</style>';
@@ -63,16 +70,18 @@ test('a link with meaningful aria-label is good', function() {
     a.className = 'trout';
     a.setAttribute('aria-label', 'Learn more about trout fishing');
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-        rule.run({scope: fixture}),
-        { elements: [], result: axs.constants.AuditResult.PASS });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [],
+        expected: axs.constants.AuditResult.PASS
+    };
+    assert.runRule(config);
 });
 
 /*
  * This test will need to be reviewed when issue #214 is addressed.
  */
-test('a link with meaningful aria-labelledby is good', function() {
+test('a link with meaningful aria-labelledby is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     // Style our link to be visually meaningful with no descendent nodes at all.
     fixture.innerHTML = '<style>a.trout::after{content: "Learn more about trout fishing"}</style>';
@@ -84,28 +93,33 @@ test('a link with meaningful aria-labelledby is good', function() {
     label.id = "trout" + Date.now();
     a.setAttribute('aria-labelledby', label.id);
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-        rule.run({scope: fixture}),
-        { elements: [], result: axs.constants.AuditResult.PASS });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [],
+        expected: axs.constants.AuditResult.PASS
+    };
+    assert.runRule(config);
 });
 
-test('a link without meaningful text is bad', function() {
+test('a link without meaningful text is bad', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var a = fixture.appendChild(document.createElement('a'));
     a.href = '#main';
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [a],
+        expected: axs.constants.AuditResult.FAIL
+    };
 
     var badLinks = ['click here.', 'Click here!', 'Learn more.', 'this page', 'this link', 'here'];
     badLinks.forEach(function(text) {
         a.textContent = text;
-        deepEqual(rule.run({scope: fixture}),
-                  { elements: [a], result: axs.constants.AuditResult.FAIL });
+        assert.runRule(config);
     });
 });
 
-test('a link with bg image and meaningful aria-label is good', function() {
+test('a link with bg image and meaningful aria-label is good', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     // Style our link to be visually meaningful with no descendent nodes at all.
     fixture.innerHTML = '<style>a.trout{background-image: url("/trout.png"); display:block; height:1em}</style>';
@@ -114,31 +128,35 @@ test('a link with bg image and meaningful aria-label is good', function() {
     a.className = 'trout';
     a.setAttribute('aria-label', 'Learn more about trout fishing');
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-        rule.run({scope: fixture}),
-        { elements: [], result: axs.constants.AuditResult.PASS });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        elements: [],
+        expected: axs.constants.AuditResult.PASS
+    };
+    assert.runRule(config);
 });
 
-test('a hidden link should not be run against the audit', function() {
+test('a hidden link should not be run against the audit', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var a = fixture.appendChild(document.createElement('a'));
     a.hidden = true;
     a.href = '#main';
     a.textContent = 'Learn more about trout fishing';
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-      rule.run({scope: fixture}),
-      { result: axs.constants.AuditResult.NA });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('an anchor tag without href attribute is ignored', function() {
+test('an anchor tag without href attribute is ignored', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     fixture.appendChild(document.createElement('a'));
 
-    var rule = axs.AuditRules.getRule('linkWithUnclearPurpose');
-    deepEqual(
-      rule.run({scope: fixture}),
-      { result: axs.constants.AuditResult.NA });
+    var config = {
+        ruleName: 'linkWithUnclearPurpose',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });

--- a/test/audits/low-contrast-test.js
+++ b/test/audits/low-contrast-test.js
@@ -1,123 +1,156 @@
 module('LowContrast');
 
-test('No text = no relevant elements', function() {
+test('No text = no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.style.backgroundColor = 'white';
   div.style.color = 'white';
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA }
-  );
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('Black on white = no problem', function() {
+test('Black on white = no problem', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.style.backgroundColor = 'white';
   div.style.color = 'black';
   div.textContent = 'Some text';
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [],
+    expected: axs.constants.AuditResult.PASS
+  };
+  assert.runRule(config);
 });
 
-test('Low contrast = fail', function() {
+test('Low contrast = fail', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.style.backgroundColor = 'white';
   div.style.color = '#aaa';  // Contrast ratio = 2.32
   div.textContent = 'Some text';
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [div], result: axs.constants.AuditResult.FAIL }
-  );
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [div],
+    expected: axs.constants.AuditResult.FAIL
+  };
+  assert.runRule(config);
 });
 
-test('Opacity is handled', function() {
+test('Opacity is handled', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var elementWithOpacity = document.createElement('div');
   elementWithOpacity.style.opacity = '0.4';
   elementWithOpacity.textContent = 'Some text';
   fixture.appendChild(elementWithOpacity);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [elementWithOpacity], result: axs.constants.AuditResult.FAIL }
-  );
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [elementWithOpacity],
+    expected: axs.constants.AuditResult.FAIL
+  };
+  assert.runRule(config);
 });
 
-test('Uses tolerance value', function() {
+test('Uses tolerance value', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.style.backgroundColor = 'white';
   div.style.color = '#777'; // Contrast ratio = 4.48
   div.textContent = 'Some text';
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [],
+    expected: axs.constants.AuditResult.PASS
+  };
+  assert.runRule(config);
 });
 
-test('Disabled button = no relevant elements', function() {
+test('Disabled button = no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var button = document.createElement('button');
   button.textContent = 'I Can Has Cheezburger?';
   button.setAttribute('disabled', 'disabled');
   fixture.appendChild(button);
-  deepEqual(axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('aria-disabled button = no relevant elements', function() {
+test('aria-disabled button = no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var button = document.createElement('button');
   button.textContent = 'I Can Has Cheezburger?';
   button.setAttribute('aria-disabled', 'true');
   fixture.appendChild(button);
-  deepEqual(axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('aria-disabled=false button = pass', function() {
+test('aria-disabled=false button = pass', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var button = document.createElement('button');
   button.textContent = 'I Can Has Cheezburger?';
   button.setAttribute('aria-disabled', 'false');
   fixture.appendChild(button);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [],
+    expected: axs.constants.AuditResult.PASS
+  };
+  assert.runRule(config);
 });
 
-test('Button in disabled fieldset = no relevant elements', function() {
+test('Button in disabled fieldset = no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var container = document.createElement('fieldset');
   container.setAttribute('disabled', 'disabled');
   var button = container.appendChild(document.createElement('button'));
   button.textContent = 'I Can Has Cheezburger?';
   fixture.appendChild(container);
-  deepEqual(axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('Button in disabled=false fieldset = no relevant elements', function() {
+test('Button in disabled=false fieldset = no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var container = document.createElement('fieldset');
   container.setAttribute('disabled', 'false');  // check that the value of disabled is irrelevant
   var button = container.appendChild(document.createElement('button'));
   button.textContent = 'I Can Has Cheezburger?';
   fixture.appendChild(container);
-  deepEqual(axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('Button in aria-disabled container = no relevant elements', function() {
+test('Button in aria-disabled container = no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var container = document.createElement('div');
   container.setAttribute('role', 'group');
@@ -127,11 +160,14 @@ test('Button in aria-disabled container = no relevant elements', function() {
   var button = container.appendChild(document.createElement('button'));
   button.textContent = 'I Can Has Cheezburger?';
   fixture.appendChild(container);
-  deepEqual(axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA });
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('Crazy button in disabled fieldset legend test = relevant elements', function() {
+test('Crazy button in disabled fieldset legend test = relevant elements', function(assert) {
   /*
    * Test this bit of the spec:
    * The disabled attribute, when specified, causes all the form control descendants of the fieldset element,
@@ -146,12 +182,16 @@ test('Crazy button in disabled fieldset legend test = relevant elements', functi
   var button = legend.appendChild(document.createElement('button'));
   button.textContent = 'I Can Has Cheezburger?';
   fixture.appendChild(container);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [],
+    expected: axs.constants.AuditResult.PASS
+  };
+  assert.runRule(config);
 });
 
-test('Even crazier button in disabled fieldset second legend test = no relevant elements', function() {
+test('Even crazier button in disabled fieldset second legend test = no relevant elements', function(assert) {
   /*
    * Test this bit of the spec:
    * The disabled attribute, when specified, causes all the form control descendants of the fieldset element,
@@ -167,11 +207,15 @@ test('Even crazier button in disabled fieldset second legend test = no relevant 
   var button = legend.appendChild(document.createElement('button'));
   button.textContent = 'I Can Has Cheezburger?';
   fixture.appendChild(container);
-  deepEqual(axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA });
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('Low contrast, disabled on undisableable = fail', function() {
+test('Low contrast, disabled on undisableable = fail', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('disabled', 'disabled');
@@ -182,8 +226,11 @@ test('Low contrast, disabled on undisableable = fail', function() {
   div.style.color = 'white';
   div.textContent = 'Some text';
   fixture.appendChild(div);
-  deepEqual(
-    axs.AuditRules.getRule('lowContrastElements').run({ scope: fixture }),
-    { elements: [div], result: axs.constants.AuditResult.FAIL }
-  );
+
+  var config = {
+    ruleName: 'lowContrastElements',
+    elements: [div],
+    expected: axs.constants.AuditResult.FAIL
+  };
+  assert.runRule(config);
 });

--- a/test/audits/main-role-on-inappropriate-element-test.js
+++ b/test/audits/main-role-on-inappropriate-element-test.js
@@ -14,63 +14,73 @@
 
 module('MainRoleOnInappropriateElement');
 
-test('No role=main -> no relevant elements', function() {
+test('No role=main -> no relevant elements', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   fixture.appendChild(div);
 
-  deepEqual(
-    axs.AuditRules.getRule('mainRoleOnInappropriateElement').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA }
-  );
+    var config = {
+        ruleName: 'mainRoleOnInappropriateElement',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('role=main on empty element === fail', function() {
+test('role=main on empty element === fail', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('role', 'main');
   fixture.appendChild(div);
 
-  deepEqual(
-    axs.AuditRules.getRule('mainRoleOnInappropriateElement').run({ scope: fixture }),
-    { elements: [div], result: axs.constants.AuditResult.FAIL }
-  );
+    var config = {
+        ruleName: 'mainRoleOnInappropriateElement',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [div]
+    };
+    assert.runRule(config);
 });
 
-test('role=main on element with textContent < 50 characters === pass', function() {
+test('role=main on element with textContent < 50 characters === pass', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('role', 'main');
   div.textContent = 'Lorem ipsum dolor sit amet.';
   fixture.appendChild(div);
 
-  deepEqual(
-    axs.AuditRules.getRule('mainRoleOnInappropriateElement').run({ scope: fixture }),
-    { elements: [div], result: axs.constants.AuditResult.FAIL }
-  );
+    var config = {
+        ruleName: 'mainRoleOnInappropriateElement',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [div]
+    };
+    assert.runRule(config);
 });
 
-test('role=main on element with textContent >= 50 characters === pass', function() {
+test('role=main on element with textContent >= 50 characters === pass', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('role', 'main');
   div.textContent = 'Lorem ipsum dolor sit amet, consectetur cras amet.';
   fixture.appendChild(div);
 
-  deepEqual(
-    axs.AuditRules.getRule('mainRoleOnInappropriateElement').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+    var config = {
+        ruleName: 'mainRoleOnInappropriateElement',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('role=main on inline element === fail', function() {
+test('role=main on inline element === fail', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var span = document.createElement('span');
   span.setAttribute('role', 'main');
   span.textContent = 'Lorem ipsum dolor sit amet, consectetur cras amet.';
   fixture.appendChild(span);
 
-  deepEqual(
-    axs.AuditRules.getRule('mainRoleOnInappropriateElement').run({ scope: fixture }),
-    { elements: [span], result: axs.constants.AuditResult.FAIL });
+    var config = {
+        ruleName: 'mainRoleOnInappropriateElement',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [span]
+    };
+    assert.runRule(config);
 });

--- a/test/audits/multiple-aria-owners-test.js
+++ b/test/audits/multiple-aria-owners-test.js
@@ -35,75 +35,102 @@
         return fixture;
     }
 
-    test('Element owned once only', function() {
+    test('Element owned once only', function(assert) {
         var fixture = setup(['theOwned']);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+        var config = {
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Multiple elements owned once only', function() {
+    test('Multiple elements owned once only', function(assert) {
         var fixture = setup(['theOwnedElement', 'theOtherOwnedElement']);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+        var config = {
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element owned once only but not found in DOM', function() {
+    test('Element owned once only but not found in DOM', function(assert) {
         var id = 'theOwnedElement';
         var fixture = setup([id]);
         var element = document.getElementById(id);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
         element.parentNode.removeChild(element);
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+        var config = {
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element owned multiple times', function() {
+    test('Element owned multiple times', function(assert) {
         var ownerIds = ['owner1', 'owner2'];
         var fixture = setup(['theOwned'], ownerIds);
         var elements = ownerIds.map(function(id) {
             return document.getElementById(id);
         });
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, elements);
+
+        var config = {
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: elements
+        };
+        assert.runRule(config);
     });
 
-    test('Multiple elements owned multiple times', function() {
+    test('Multiple elements owned multiple times', function(assert) {
         var ownerIds = ['owner1', 'owner2', 'owner3'];
         var fixture = setup(['theOwnedElement', 'theOtherOwnedElement'], ownerIds);
         var elements = ownerIds.map(function(id) {
             return document.getElementById(id);
         });
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, elements);
+
+        var config = {
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: elements
+        };
+        assert.runRule(config);
     });
 
 
-    test('Multiple elements one owned multiple times', function() {
+    test('Multiple elements one owned multiple times', function(assert) {
         var ownerIds = ['owner1', 'owner2'];
         var ownedElements = ['theOwnedElement', 'theOtherOwnedElement'];
         var fixture = setup(ownedElements, ownerIds, ownedElements[0]);
         var elements = ownerIds.map(function(id) {
             return document.getElementById(id);
         });
-        var rule = axs.AuditRules.getRule(RULE_NAME);
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, elements);
+
+        var config = {
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: elements
+        };
+        assert.runRule(config);
     });
 
-    test('Using ignoreSelectors', function() {
+    test('Using ignoreSelectors', function(assert) {
         var fixture = setup(['theOwned'], ['owner1', 'owner2']);
-        var rule = axs.AuditRules.getRule(RULE_NAME);
         var ignoreSelectors = ['#owner1', '#owner2'];
-        var result = rule.run({
+
+        var config = {
             ignoreSelectors: ignoreSelectors,
-            scope: fixture });
-        equal(result.result, axs.constants.AuditResult.NA);
+            scope: fixture,
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config);
     });
 })();

--- a/test/audits/multiple-labelable-elements-per-label-test.js
+++ b/test/audits/multiple-labelable-elements-per-label-test.js
@@ -14,7 +14,7 @@
 
 module("multipleLabelableElementsPerLabel");
 
-test("one labelable element within a label tag", function() {
+test("one labelable element within a label tag", function(assert) {
   var fixture = document.getElementById("qunit-fixture");
   var label = document.createElement("label");
   var input = document.createElement("input");
@@ -22,17 +22,15 @@ test("one labelable element within a label tag", function() {
   fixture.appendChild(label);
   label.appendChild(input);
 
-  var rule = axs.AuditRules.getRule("multipleLabelableElementsPerLabel");
-  var result = rule.run({ scope: fixture });
-  var expected = {
-    elements: [],
-    result: axs.constants.AuditResult.PASS
+  var config = {
+    ruleName: "multipleLabelableElementsPerLabel",
+    expected: axs.constants.AuditResult.PASS,
+    elements: []
   };
-
-  deepEqual(result, expected, "passes the audit with no matching elements");
+  assert.runRule(config, "passes the audit with no matching elements");
 });
 
-test("multiple labelable elements within a label tag", function() {
+test("multiple labelable elements within a label tag", function(assert) {
   var fixture = document.getElementById("qunit-fixture");
   var label = document.createElement("label");
   var input1 = document.createElement("input");
@@ -42,12 +40,10 @@ test("multiple labelable elements within a label tag", function() {
   label.appendChild(input1);
   label.appendChild(input2);
 
-  var rule = axs.AuditRules.getRule("multipleLabelableElementsPerLabel");
-  var result = rule.run({ scope: fixture });
-  var expected = {
-    elements: [label],
-    result: axs.constants.AuditResult.FAIL
+  var config = {
+    ruleName: "multipleLabelableElementsPerLabel",
+    expected: axs.constants.AuditResult.FAIL,
+    elements: [label]
   };
-
-  deepEqual(result, expected, "fails the audit on that label");
+  assert.runRule(config, "fails the audit on that label");
 });

--- a/test/audits/non-existent-aria-related-element-test.js
+++ b/test/audits/non-existent-aria-related-element-test.js
@@ -1,4 +1,4 @@
-module('NonExistentAriaRelatedElement');
+module('NonExistentRelatedElement');
 [
   'aria-activedescendant',  // strictly speaking sometests do not apply to this
   'aria-controls',
@@ -18,7 +18,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.PASS,
             elements: []
         };
@@ -33,7 +33,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.FAIL,
             elements: [refererElement]
         };
@@ -49,7 +49,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.FAIL,
             elements: [refererElement]
         };
@@ -65,7 +65,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.FAIL,
             elements: [refererElement]
         };
@@ -89,7 +89,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.PASS,
             elements: []
         };
@@ -110,7 +110,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.FAIL,
             elements: [refererElement]
         };
@@ -131,7 +131,7 @@ module('NonExistentAriaRelatedElement');
         fixture.appendChild(refererElement);
 
         var config = {
-            ruleName: 'nonExistentAriaRelatedElement',
+            ruleName: 'nonExistentRelatedElement',
             expected: axs.constants.AuditResult.NA,
             ignoreSelectors: ['#labelledbyElement2']
         };

--- a/test/audits/non-existent-aria-related-element-test.js
+++ b/test/audits/non-existent-aria-related-element-test.js
@@ -6,7 +6,7 @@ module('NonExistentAriaRelatedElement');
   'aria-flowto',
   'aria-labelledby',
   'aria-owns'].forEach(function(testProp) {
-    test('Element exists, single ' + testProp + ' value', function() {
+    test('Element exists, single ' + testProp + ' value', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var referentElement = document.createElement('div');
         referentElement.textContent = 'label';
@@ -17,50 +17,62 @@ module('NonExistentAriaRelatedElement');
         refererElement.setAttribute(testProp, 'theLabel');
         fixture.appendChild(refererElement);
 
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element doesn\'t exist, single ' + testProp + ' value', function() {
+    test('Element doesn\'t exist, single ' + testProp + ' value', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var refererElement = document.createElement('div');
         refererElement.setAttribute(testProp, 'notALabel');
         fixture.appendChild(refererElement);
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [refererElement]);
+
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [refererElement]
+        };
+        assert.runRule(config);
     });
 
-    test('Element doesn\'t exist, single ' + testProp + ' value with aria-busy', function() {
+    test('Element doesn\'t exist, single ' + testProp + ' value with aria-busy', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var refererElement = document.createElement('div');
         refererElement.setAttribute(testProp, 'notALabel');
         refererElement.setAttribute('aria-busy', 'true');
         fixture.appendChild(refererElement);
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [refererElement]);
+
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [refererElement]
+        };
+        assert.runRule(config);
     });
 
-    test('Element doesn\'t exist, single ' + testProp + ' value with aria-hidden', function() {
+    test('Element doesn\'t exist, single ' + testProp + ' value with aria-hidden', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var refererElement = document.createElement('div');
         refererElement.setAttribute(testProp, 'notALabel');
         refererElement.setAttribute('aria-hidden', 'true');
         fixture.appendChild(refererElement);
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [refererElement]);
+
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [refererElement]
+        };
+        assert.runRule(config);
     });
 
-    test('Multiple referent elements exist with ' + testProp, function() {
+    test('Multiple referent elements exist with ' + testProp, function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var referentElement = document.createElement('div');
         referentElement.textContent = 'label';
@@ -76,13 +88,16 @@ module('NonExistentAriaRelatedElement');
         refererElement.setAttribute(testProp, 'theLabel theOtherLabel');
         fixture.appendChild(refererElement);
 
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        deepEqual(rule.run({ scope: fixture }),
-                  { elements: [], result: axs.constants.AuditResult.PASS });
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
 
     });
 
-    test('One element doesn\'t exist, multiple ' + testProp, function() {
+    test('One element doesn\'t exist, multiple ' + testProp, function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var referentElement = document.createElement('div');
@@ -93,13 +108,16 @@ module('NonExistentAriaRelatedElement');
         var refererElement = document.createElement('div');
         refererElement.setAttribute(testProp, 'theLabel notALabel');
         fixture.appendChild(refererElement);
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        var result = rule.run({ scope: fixture });
-        equal(result.result, axs.constants.AuditResult.FAIL);
-        deepEqual(result.elements, [refererElement]);
+
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [refererElement]
+        };
+        assert.runRule(config);
     });
 
-    test('Using ignoreSelectors with ' + testProp, function() {
+    test('Using ignoreSelectors with ' + testProp, function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var referentElement = document.createElement('div');
@@ -112,9 +130,11 @@ module('NonExistentAriaRelatedElement');
         refererElement.setAttribute(testProp, 'theLabel2 notALabel2');
         fixture.appendChild(refererElement);
 
-        var rule = axs.AuditRules.getRule('nonExistentAriaRelatedElement');
-        var ignoreSelectors = ['#labelledbyElement2'];
-        var result = rule.run({ ignoreSelectors: ignoreSelectors, scope: fixture });
-        equal(result.result, axs.constants.AuditResult.NA);
+        var config = {
+            ruleName: 'nonExistentAriaRelatedElement',
+            expected: axs.constants.AuditResult.NA,
+            ignoreSelectors: ['#labelledbyElement2']
+        };
+        assert.runRule(config);
     });
 });

--- a/test/audits/page-without-title-test.js
+++ b/test/audits/page-without-title-test.js
@@ -1,28 +1,31 @@
 module("Page titles");
 
-test("Page titles must be present and non-empty", function() {
-    var rule = axs.AuditRules.getRule('pageWithoutTitle');
+test("Page titles must be present and non-empty", function(assert) {
 
     // Remove the title element from the qunit test page.
     var title = document.querySelector('title');
     if (title && title.parentNode)
         title.parentNode.removeChild(title);
 
+    var config = {
+        scope: document.documentElement,
+        ruleName: 'pageWithoutTitle',
+        expected: axs.constants.AuditResult.FAIL
+    };
+
     // This one fails because there is no title element.
-    equal(rule.run().result,
-          axs.constants.AuditResult.FAIL);
+    assert.runRule(config);
 
     var head = document.querySelector('head');
     var blankTitle = document.createElement('title');
     head.appendChild(blankTitle);
 
     // This one fails because the title element is blank.
-    equal(rule.run().result,
-          axs.constants.AuditResult.FAIL);
+    assert.runRule(config);
 
     blankTitle.textContent = 'foo';
-    equal(rule.run().result,
-          axs.constants.AuditResult.PASS);
+    config.expected = axs.constants.AuditResult.PASS;
+    assert.runRule(config);
 
     // Put it back the way it was...
     blankTitle.parentNode.replaceChild(title, blankTitle);

--- a/test/audits/required-aria-attribute-missing-test.js
+++ b/test/audits/required-aria-attribute-missing-test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 (function() {
     module('RequiredAriaAttributeMissing');
-    var rule = axs.AuditRules.getRule('requiredAriaAttributeMissing');
+    var RULE_NAME = 'requiredAriaAttributeMissing';
     /**
      * Input types that take the role 'spinbutton'.
      *
@@ -22,60 +22,73 @@
     var SPINBUTTON_TYPES = ['date', 'datetime', 'datetime-local',
                             'month', 'number', 'time', 'week'];
 
-    test('Explicit states required all present', function() {
+    test('Explicit states required all present', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget.setAttribute('role', 'slider');
         widget.setAttribute('aria-valuemax', '79');
         widget.setAttribute('aria-valuemin', '10');
         widget.setAttribute('aria-valuenow', '50');
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Explicit states required but none present', function() {
+    test('Explicit states required but none present', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = {
-                elements: [widget],
-                result: axs.constants.AuditResult.FAIL };
         widget.setAttribute('role', 'slider');
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config);
     });
 
-    test('Explicit states required only supported states present', function() {
+    test('Explicit states required only supported states present', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = {
-                elements: [widget],
-                result: axs.constants.AuditResult.FAIL };
         widget.setAttribute('role', 'slider');
         widget.setAttribute('aria-orientation', 'horizontal');  // supported
         widget.setAttribute('aria-haspopup', 'false');  // global
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config);
     });
 
-    test('Explicit states required, one not present', function() {
+    test('Explicit states required, one not present', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = {
-                elements: [widget],
-                result: axs.constants.AuditResult.FAIL };
         widget.setAttribute('role', 'slider');
         widget.setAttribute('aria-valuemin', '10');
         widget.setAttribute('aria-valuenow', '50');
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config);
     });
 
     /*
      * Elements with the role scrollbar have an implicit aria-orientation value
      * of vertical.
      */
-    test('Explicit states present, aria implicit state present', function() {
+    test('Explicit states present, aria implicit state present', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         var widget2 = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget2.id = 'controlledElement';
         widget.setAttribute('role', 'scrollbar');
         widget.setAttribute('aria-valuemax', '79');
@@ -83,48 +96,67 @@
         widget.setAttribute('aria-valuenow', '50');
         widget.setAttribute('aria-orientation', 'horizontal');
         widget.setAttribute('aria-controls', widget2.id);
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
     /*
      * Elements with the role scrollbar have an implicit aria-orientation value
      * of vertical.
      */
-    test('Explicit states present, aria implicit state absent', function() {
+    test('Explicit states present, aria implicit state absent', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         var widget2 = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget2.id = 'controlledElement';
         widget.setAttribute('role', 'scrollbar');
         widget.setAttribute('aria-valuemax', '79');
         widget.setAttribute('aria-valuemin', '10');
         widget.setAttribute('aria-valuenow', '50');
         widget.setAttribute('aria-controls', widget2.id);
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Required states provided implcitly by html', function() {
+    test('Required states provided implcitly by html', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('input'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget.setAttribute('type', 'range');
         // setting role is redundant but needs to be ignored by this audit
         widget.setAttribute('role', 'slider');
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
     SPINBUTTON_TYPES.forEach(function(type) {
-        test('Required states provided implcitly by input type ' + type, function() {
+        test('Required states provided implcitly by input type ' + type, function(assert) {
             var fixture = document.getElementById('qunit-fixture');
             var widget = fixture.appendChild(document.createElement('input'));
-            var expected = {
-                    elements: [],
-                    result: axs.constants.AuditResult.PASS };
             widget.setAttribute('type', type);
             // setting role is redundant but needs to be ignored by this audit
             widget.setAttribute('role', 'spinbutton');
-            deepEqual(rule.run({ scope: fixture }), expected);
+
+            var config = {
+                ruleName: RULE_NAME,
+                expected: axs.constants.AuditResult.PASS,
+                elements: []
+            };
+            assert.runRule(config);
         });
     });
 

--- a/test/audits/required-owned-aria-role-missing-test.js
+++ b/test/audits/required-owned-aria-role-missing-test.js
@@ -13,8 +13,7 @@
 // limitations under the License.
 module('RequiredOwnedAriaRoleMissing');
 
-test('Explicit role on container and required elements all explicitly present', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('Explicit role on container and required elements all explicitly present', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     container.setAttribute('role', 'list');
@@ -23,13 +22,15 @@ test('Explicit role on container and required elements all explicitly present', 
         item.setAttribute('role', 'listitem');
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Explicit role on container and required elements all explicitly present via aria-owns', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('Explicit role on container and required elements all explicitly present via aria-owns', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     var siblingContainer = fixture.appendChild(document.createElement('div'));
@@ -42,38 +43,45 @@ test('Explicit role on container and required elements all explicitly present vi
         item.setAttribute('id', id);
     }
     container.setAttribute('aria-owns', ids.join(' '));
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+
     equal(container.childNodes.length, 0);  // paranoid check to ensure the test itself is correct
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('Explicit role on container and required elements missing', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('Explicit role on container and required elements missing', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     container.setAttribute('role', 'list');
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.FAIL);
-    deepEqual(actual.elements, [container]);
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [container]
+    };
+    assert.runRule(config);
 });
 
-test('Explicit role on aria-busy container and required elements missing', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('Explicit role on aria-busy container and required elements missing', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     container.setAttribute('role', 'list');
     container.setAttribute('aria-busy', 'true');
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
 
-test('Explicit role on container and required elements all implicitly present', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('Explicit role on container and required elements all implicitly present', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('ul'));
     container.setAttribute('role', 'list');  // This is bad practice (redundant role) but that's a different test
@@ -81,26 +89,33 @@ test('Explicit role on container and required elements all implicitly present', 
         container.appendChild(document.createElement('li'));
     }
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.PASS);
-    deepEqual(actual.elements, []);
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('No role', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('No role', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     fixture.appendChild(document.createElement('div'));
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA);
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });
 
-test('Role with no required elements', function() {
-    var rule = axs.AuditRules.getRule('requiredOwnedAriaRoleMissing');
+test('Role with no required elements', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var container = fixture.appendChild(document.createElement('div'));
     container.setAttribute('role', 'checkbox');
 
-    var actual = rule.run({ scope: fixture });
-    equal(actual.result, axs.constants.AuditResult.NA);
+    var config = {
+        ruleName: 'requiredOwnedAriaRoleMissing',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });

--- a/test/audits/role-tooltip-requires-described-by-test.js
+++ b/test/audits/role-tooltip-requires-described-by-test.js
@@ -1,6 +1,6 @@
 module('RoleTooltipRequiresDescribedBy');
 
-test('role tooltip with a corresponding aria-describedby should pass', function() {
+test('role tooltip with a corresponding aria-describedby should pass', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var tooltip = document.createElement('div');
     var trigger = document.createElement('div');
@@ -9,13 +9,16 @@ test('role tooltip with a corresponding aria-describedby should pass', function(
     tooltip.setAttribute('role', 'tooltip');
     tooltip.setAttribute('id', 'tooltip1');
     trigger.setAttribute('aria-describedby', 'tooltip1');
-    deepEqual(
-        axs.AuditRules.getRule('roleTooltipRequiresDescribedby').run({ scope: fixture }),
-        { elements: [], result: axs.constants.AuditResult.PASS }
-    );
+
+    var config = {
+        ruleName: 'roleTooltipRequiresDescribedby',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('role tooltip with multiple corresponding aria-describedby should pass', function() {
+test('role tooltip with multiple corresponding aria-describedby should pass', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var tooltip = document.createElement('div');
     var trigger1 = document.createElement('div');
@@ -27,25 +30,31 @@ test('role tooltip with multiple corresponding aria-describedby should pass', fu
     tooltip.setAttribute('id', 'tooltip1');
     trigger1.setAttribute('aria-describedby', 'tooltip1');
     trigger2.setAttribute('aria-describedby', 'tooltip1');
-    deepEqual(
-        axs.AuditRules.getRule('roleTooltipRequiresDescribedby').run({ scope: fixture }),
-        { elements: [], result: axs.constants.AuditResult.PASS }
-    );
+
+    var config = {
+        ruleName: 'roleTooltipRequiresDescribedby',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test('role tooltip without a aria-describedby should fail', function() {
+test('role tooltip without a aria-describedby should fail', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var tooltip = document.createElement('div');
     fixture.appendChild(tooltip);
     tooltip.setAttribute('role', 'tooltip');
     tooltip.setAttribute('id', 'tooltip1');
-    deepEqual(
-        axs.AuditRules.getRule('roleTooltipRequiresDescribedby').run({ scope: fixture }),
-        { elements: [tooltip], result: axs.constants.AuditResult.FAIL }
-    );
+
+    var config = {
+        ruleName: 'roleTooltipRequiresDescribedby',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [tooltip]
+    };
+    assert.runRule(config);
 });
 
-test('role tooltip without a corresponding aria-describedby should fail', function() {
+test('role tooltip without a corresponding aria-describedby should fail', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var tooltip = document.createElement('div');
     var trigger = document.createElement('div');
@@ -54,13 +63,16 @@ test('role tooltip without a corresponding aria-describedby should fail', functi
     tooltip.setAttribute('role', 'tooltip');
     tooltip.setAttribute('id', 'tooltip1');
     trigger.setAttribute('aria-describedby', 'tooltip2');
-    deepEqual(
-        axs.AuditRules.getRule('roleTooltipRequiresDescribedby').run({ scope: fixture }),
-        { elements: [tooltip], result: axs.constants.AuditResult.FAIL }
-    );
+
+    var config = {
+        ruleName: 'roleTooltipRequiresDescribedby',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [tooltip]
+    };
+    assert.runRule(config);
 });
 
-test('a hidden tooltip without a corresponding aria-describedby should not fail', function() {
+test('a hidden tooltip without a corresponding aria-describedby should not fail', function(assert) {
     var fixture = document.getElementById('qunit-fixture');
     var tooltip = document.createElement('div');
     var trigger = document.createElement('div');
@@ -70,8 +82,10 @@ test('a hidden tooltip without a corresponding aria-describedby should not fail'
     tooltip.setAttribute('role', 'tooltip');
     tooltip.setAttribute('id', 'tooltip1');
     trigger.setAttribute('aria-describedby', 'tooltip2');
-    deepEqual(
-        axs.AuditRules.getRule('roleTooltipRequiresDescribedby').run({ scope: fixture }),
-        { result: axs.constants.AuditResult.NA }
-    );
+
+    var config = {
+        ruleName: 'roleTooltipRequiresDescribedby',
+        expected: axs.constants.AuditResult.NA
+    };
+    assert.runRule(config);
 });

--- a/test/audits/tab-index-greater-than-zero-test.js
+++ b/test/audits/tab-index-greater-than-zero-test.js
@@ -14,8 +14,7 @@
 
 module("tabIndex values");
 
-test("tabIndex is 0 or -1 passes the audit", function() {
-  var rule = axs.AuditRules.getRule("tabIndexGreaterThanZero");
+test("tabIndex is 0 or -1 passes the audit", function(assert) {
   var fixture = document.getElementById('qunit-fixture');
 
   var listItem = document.createElement("li");
@@ -25,19 +24,25 @@ test("tabIndex is 0 or -1 passes the audit", function() {
   listItem.tabIndex = -1;
   heading.tabIndex = 0;
 
-  var output = rule.run({ scope: fixture });
-  equal(output.result, axs.constants.AuditResult.PASS);
+    var config = {
+        ruleName: 'tabIndexGreaterThanZero',
+        expected: axs.constants.AuditResult.PASS,
+        elements: []
+    };
+    assert.runRule(config);
 });
 
-test("tabIndex with a positive integer fails the audit", function() {
-  var rule = axs.AuditRules.getRule("tabIndexGreaterThanZero");
+test("tabIndex with a positive integer fails the audit", function(assert) {
   var fixture = document.getElementById('qunit-fixture');
 
   var listItem = document.createElement("li");
   fixture.appendChild(listItem);
   listItem.tabIndex = 1;
 
-  var output = rule.run({ scope: fixture });
-  equal(output.result, axs.constants.AuditResult.FAIL);
-  deepEqual(output.elements, [listItem]);
+    var config = {
+        ruleName: 'tabIndexGreaterThanZero',
+        expected: axs.constants.AuditResult.FAIL,
+        elements: [listItem]
+    };
+    assert.runRule(config);
 });

--- a/test/audits/table-has-appropriate-headers-test.js
+++ b/test/audits/table-has-appropriate-headers-test.js
@@ -1,6 +1,7 @@
 module('TableHasAppropriateHeaders');
 
 (function() {
+    var RULE_NAME = 'tableHasAppropriateHeaders';
     /**
      * Builds a tr with the given cell tags
      *
@@ -61,21 +62,22 @@ module('TableHasAppropriateHeaders');
         return table;
     }
 
-    test('Table with no child elements', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with no child elements', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = document.createElement('table');
 
         fixture.appendChild(table);
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.NA);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA,
+            elements: [table]  // Yeah this is weird but that's how the test used to be
+        };
+        assert.runRule(config);
     });
 
-    test('Table with only THEAD', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with only THEAD', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = document.createElement('table');
@@ -86,13 +88,15 @@ module('TableHasAppropriateHeaders');
 
         fixture.appendChild(table);
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.NA);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with only TFOOT', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with only TFOOT', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = document.createElement('table');
@@ -103,13 +107,15 @@ module('TableHasAppropriateHeaders');
 
         fixture.appendChild(table);
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.NA);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with only TBODY', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with only TBODY', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = document.createElement('table');
@@ -120,13 +126,15 @@ module('TableHasAppropriateHeaders');
 
         fixture.appendChild(table);
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.NA);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with a header row', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with a header row', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         fixture.appendChild(buildTable(
@@ -137,13 +145,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table with an incomplete header row', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with an incomplete header row', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = fixture.appendChild(buildTable(
@@ -154,13 +164,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with a header column', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with a header column', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         fixture.appendChild(buildTable(
@@ -171,13 +183,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table with an incomplete header column', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with an incomplete header column', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = fixture.appendChild(buildTable(
@@ -188,13 +202,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table uses a grid layout', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table uses a grid layout', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         fixture.appendChild(buildTable(
@@ -205,13 +221,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table with no headers at all', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with no headers at all', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = fixture.appendChild(buildTable(
@@ -222,13 +240,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with thead and tbody that has a header row', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with thead and tbody that has a header row', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         fixture.appendChild(buildTableWithThead(
@@ -239,13 +259,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table with thead and tbody with an incomplete header row', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with thead and tbody with an incomplete header row', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = fixture.appendChild(buildTableWithThead(
@@ -256,13 +278,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with thead and tbody that has a header column', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with thead and tbody that has a header column', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         fixture.appendChild(buildTableWithThead(
@@ -273,13 +297,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table with thead and tbody with an incomplete header column', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with thead and tbody with an incomplete header column', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = fixture.appendChild(buildTableWithThead(
@@ -290,13 +316,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table with thead and tbody using a grid layout', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with thead and tbody using a grid layout', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         fixture.appendChild(buildTableWithThead(
@@ -307,13 +335,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table with thead and tbody with no headers at all', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table with thead and tbody with no headers at all', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = fixture.appendChild(buildTableWithThead(
@@ -324,13 +354,15 @@ module('TableHasAppropriateHeaders');
           ]
         ));
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 
-    test('Table used for layout with no headers at all', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table used for layout with no headers at all', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = buildTable([
@@ -344,13 +376,15 @@ module('TableHasAppropriateHeaders');
 
         fixture.appendChild(table);
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.PASS);
-        deepEqual(actual.elements, []);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Table used for layout with headers', function () {
-        var rule = axs.AuditRules.getRule('tableHasAppropriateHeaders');
+    test('Table used for layout with headers', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
 
         var table = buildTable([
@@ -364,8 +398,11 @@ module('TableHasAppropriateHeaders');
 
         fixture.appendChild(table);
 
-        var actual = rule.run({scope: fixture});
-        equal(actual.result, axs.constants.AuditResult.FAIL);
-        deepEqual(actual.elements, [table]);
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [table]
+        };
+        assert.runRule(config);
     });
 })();

--- a/test/audits/uncontrolled-tabpanel-test.js
+++ b/test/audits/uncontrolled-tabpanel-test.js
@@ -14,32 +14,34 @@
 
 module('UncontrolledTabpanel');
 
-test('No roles === NA.', function() {
+test('No roles === NA.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   for (var i = 0; i < 10; i++)
     fixture.appendChild(document.createElement('div'));
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('No elements with role tabpanel === NA.', function() {
+test('No elements with role tabpanel === NA.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var div = document.createElement('div');
   div.setAttribute('role', 'tablist');
   fixture.appendChild(div);
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { result: axs.constants.AuditResult.NA }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.NA
+  };
+  assert.runRule(config);
 });
 
-test('Tabpanel with aria-labelledby === PASS.', function() {
+test('Tabpanel with aria-labelledby === PASS.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var tabList = document.createElement('div');
@@ -55,13 +57,15 @@ test('Tabpanel with aria-labelledby === PASS.', function() {
   tabPanel.setAttribute('aria-labelledby', 'tabId');
   fixture.appendChild(tabPanel);
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.PASS,
+    elements: []
+  };
+  assert.runRule(config);
 });
 
-test('Tabpanel which is controlled via aria-controls on the tab === PASS.', function() {
+test('Tabpanel which is controlled via aria-controls on the tab === PASS.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var tabList = document.createElement('div');
@@ -77,16 +81,18 @@ test('Tabpanel which is controlled via aria-controls on the tab === PASS.', func
   tabPanel.setAttribute('id', 'tabpanelId');
   fixture.appendChild(tabPanel);
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.PASS,
+    elements: []
+  };
+  assert.runRule(config);
 });
 
 // If tabpanels were added dynamically with JS, then a tab might not always have a tab panel. This
 // test ensures that the audit is only checking for a tabpanel without a tab, not a tab without a
 // tabpanel.
-test('Tabpanel which is controlled via aria-controls on its tab when there is more than one tab === PASS.', function() {
+test('Tabpanel which is controlled via aria-controls on its tab when there is more than one tab === PASS.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var tabList = document.createElement('div');
@@ -107,13 +113,15 @@ test('Tabpanel which is controlled via aria-controls on its tab when there is mo
   tabPanel.setAttribute('id', 'tabpanelId');
   fixture.appendChild(tabPanel);
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { elements: [], result: axs.constants.AuditResult.PASS }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.PASS,
+    elements: []
+  };
+  assert.runRule(config);
 });
 
-test('Tabpanel which is not controlled or labeled by a tab === FAIL.', function() {
+test('Tabpanel which is not controlled or labeled by a tab === FAIL.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
   var tabList = document.createElement('div');
@@ -127,13 +135,15 @@ test('Tabpanel which is not controlled or labeled by a tab === FAIL.', function(
   tabPanel.setAttribute('role', 'tabpanel');
   fixture.appendChild(tabPanel);
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { elements: [tabPanel], result: axs.constants.AuditResult.FAIL }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.FAIL,
+    elements: [tabPanel]
+  };
+  assert.runRule(config);
 });
 
-test('Tabpanel which is labeled by something other than a tab and not controlled by a tab == FAIL.', function() {
+test('Tabpanel which is labeled by something other than a tab and not controlled by a tab == FAIL.', function(assert) {
   // Setup fixture
   var fixture = document.getElementById('qunit-fixture');
 
@@ -146,8 +156,10 @@ test('Tabpanel which is labeled by something other than a tab and not controlled
   notATab.setAttribute('id', 'not-a-tab');
   fixture.appendChild(notATab);
 
-  deepEqual(
-    axs.AuditRules.getRule('uncontrolledTabpanel').run({ scope: fixture }),
-    { elements: [tabPanel], result: axs.constants.AuditResult.FAIL }
-  );
+  var config = {
+    ruleName: 'uncontrolledTabpanel',
+    expected: axs.constants.AuditResult.FAIL,
+    elements: [tabPanel]
+  };
+  assert.runRule(config);
 });

--- a/test/audits/unsupported-aria-attribute-test.js
+++ b/test/audits/unsupported-aria-attribute-test.js
@@ -13,73 +13,97 @@
 // limitations under the License.
 (function() {
     module('UnupportedAriaAttribute');
-    var rule = axs.AuditRules.getRule('unsupportedAriaAttribute');
+    var RULE_NAME = 'unsupportedAriaAttribute';
 
-    test('Element with role and global, supported and required attributes', function() {
+    test('Element with role and global, supported and required attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-hidden', 'false');  // global
         widget.setAttribute('aria-required', 'true');  // supported
         widget.setAttribute('aria-valuemax', '79');  // required
         widget.setAttribute('aria-valuemin', '10');  // required
         widget.setAttribute('aria-valuenow', '50');  // required
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element with no role and global attributes only', function() {
+    test('Element with no role and global attributes only', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var div = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         div.setAttribute('aria-hidden', 'false');  // global
         div.setAttribute('aria-label', 'bananas'); // global
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
     /*
      * This rule shouldn't care if required and/or supported roles are missing.
      */
-    test('Element with role and global but missing supported and required attributes', function() {
+    test('Element with role and global but missing supported and required attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-hidden', 'false');  // global (so the audit will encounter this element)
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Element with role and known but unsupported attributes', function() {
+    test('Element with role and known but unsupported attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
         widget.setAttribute('role', 'group');
         widget.setAttribute('aria-required', 'true');  // unsupported
         widget.setAttribute('aria-valuemax', '79');  // unsupported
         widget.setAttribute('aria-valuemin', '10');  // unsupported
         widget.setAttribute('aria-valuenow', '50');  // unsupported
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config);
     });
 
     /*
      * This rule shouldn't care if we put ARIA attributes on elements that shouldn't have them.
      */
-    test('Element with role and global but missing supported and required attributes', function() {
+    test('Element with role and global but missing supported and required attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('meta'));  // note, a reserved HTML element
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-hidden', 'false');  // global (so the audit will encounter this element)
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
     /*
      * This test shouldn't care if there are unknown aria- attributes.
      */
-    test('Element with a role and unknown aria- attribute', function() {
+    test('Element with a role and unknown aria- attribute', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-labeledby', 'false');  // unknown
         widget.setAttribute('aria-hidden', 'false');  // global
@@ -87,85 +111,129 @@
         widget.setAttribute('aria-valuemax', '79');  // required
         widget.setAttribute('aria-valuemin', '10');  // required
         widget.setAttribute('aria-valuenow', '50');  // required
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
     /*
      * This rule definitely needs to visit elements with no role attribute.
      */
-    test('Element with no role and unknown aria- attribute', function() {
+    test('Element with no role and unknown aria- attribute', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('aria-required', 'true');  // unsupported
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config);
     });
 
     /*
      * This rule can ignore elements with no aria- attributes.
      */
-    test('Element with role but no aria- attributes', function() {
+    test('Element with role but no aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config);
     });
 
     /*
      * This rule can ignore elements with only unknown aria- attributes.
      */
-    test('Element with role but no aria- attributes', function() {
+    test('Element with role but no aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('role', 'spinbutton');
         widget.setAttribute('aria-cucumber', 'true');  // unknown
-        var expected = { result: axs.constants.AuditResult.NA };
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.NA
+        };
+        assert.runRule(config);
     });
 
-    test('Element with no role and some global, some unsupported aria- attributes', function() {
+    test('Element with no role and some global, some unsupported aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('div'));
         widget.setAttribute('aria-busy', 'false');  // global
         widget.setAttribute('aria-hidden', 'false');  // global
         widget.setAttribute('aria-posinset', '10');  // unsupported
-        var expected = { elements: [widget], result: axs.constants.AuditResult.FAIL };
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.FAIL,
+            elements: [widget]
+        };
+        assert.runRule(config);
     });
 
-	test('Element with no role and global aria- attributes', function() {
+    test('Element with no role and global aria- attributes', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('input'));
         widget.type = "text";
         widget.setAttribute('aria-label', 'This is my label');  // global
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected);
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config);
     });
 
-    test('Input with no type attribute with no role and aria-required', function() {
+    test('Input with no type attribute with no role and aria-required', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('input'));
         widget.setAttribute('aria-required', 'true');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'An input with no type is a textbox');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'An input with no type is a textbox');
     });
 
-    test('Input with type=text attribute with no role and aria-required', function() {
+    test('Input with type=text attribute with no role and aria-required', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('input'));
         widget.setAttribute('type', 'text');
         widget.setAttribute('aria-required', 'true');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'A text input is a textbox');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'A text input is a textbox');
     });
 
-    test('Input with type=text property with no role and aria-required', function() {
+    test('Input with type=text property with no role and aria-required', function(assert) {
         var fixture = document.getElementById('qunit-fixture');
         var widget = fixture.appendChild(document.createElement('input'));
         widget.type = 'text';
         widget.setAttribute('aria-required', 'true');
-        var expected = { elements: [], result: axs.constants.AuditResult.PASS };
-        deepEqual(rule.run({ scope: fixture }), expected, 'A text input is a textbox');
+
+        var config = {
+            ruleName: RULE_NAME,
+            expected: axs.constants.AuditResult.PASS,
+            elements: []
+        };
+        assert.runRule(config, 'A text input is a textbox');
     });
 })();

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,7 @@
 <!-- QUnit framework bits -->
     <link rel="stylesheet" href="qunit.css">
     <script src="qunit.js"></script>
+    <script src="testUtils.js"></script>
 <!-- Source -->
     <script src="../lib/closure-library/closure/goog/base.js"></script>
     <script src="../src/js/axs.js"></script>

--- a/test/js/audit-configuration-test.js
+++ b/test/js/audit-configuration-test.js
@@ -13,6 +13,7 @@ test("Basic AuditConfiguration with no customisation", function() {
   var fixtures = document.getElementById('qunit-fixture');
   var auditConfig = new axs.AuditConfiguration();
   auditConfig.scope = fixtures;  // limit scope to just fixture element
+  auditConfig.walkDom = false;  // for performance reasons ensure that the entire DOM is not traversed
   var results = axs.Audit.run(auditConfig);
   equal(this.auditRules_.length, results.length);
   var sortedAuditRules = this.auditRules_.sort();
@@ -34,6 +35,7 @@ test("Configure severity of an audit rule", function() {
 
   var auditConfig = new axs.AuditConfiguration();
   auditConfig.scope = fixtures;  // limit scope to just fixture element
+  auditConfig.walkDom = false;  // for performance reasons ensure that the entire DOM is not traversed
   auditConfig.setSeverity('badAriaRole', axs.constants.Severity.WARNING);
   var results = axs.Audit.run(auditConfig);
   for (var i = 0; i < results.length; i++) {
@@ -73,6 +75,7 @@ test("Configure the number of results returned", function() {
   var auditConfig = new axs.AuditConfiguration();
   auditConfig.auditRulesToRun = ['badAriaRole'];
   auditConfig.scope = fixture;  // limit scope to just fixture element
+  auditConfig.walkDom = false;
 
   var results = axs.Audit.run(auditConfig);
   equal(results.length, 1);
@@ -92,6 +95,7 @@ test('Configure audit rules to ignore', function() {
 
   var auditConfig = new axs.AuditConfiguration();
   auditConfig.scope = fixture;  // limit scope to just fixture element
+  auditConfig.walkDom = false;
 
   var results = axs.Audit.run(auditConfig);
   equal(true, results.some(function(result) {
@@ -114,7 +118,7 @@ console.warn = function(msg) {
 
 test("Unsupported Rules Warning shown first and only first time audit ran", function() {
   var auditConfig = new axs.AuditConfiguration();
-
+  auditConfig.walkDom = false;  // for performance reasons ensure that the entire DOM is not traversed
   // This should not be touched by an end-user, but needs to be set here,
   // because the unit tests run multiple times Audit.run()
   axs.Audit.unsupportedRulesWarningShown = false;
@@ -133,6 +137,7 @@ test("Unsupported Rules Warning not shown if showUnsupportedRulesWarning set to 
   // This should not be touched by an end-user, but needs to be set here,
   // because the unit tests run multiple times Audit.run()
   axs.Audit.unsupportedRulesWarningShown = false;
+  auditConfig.walkDom = false;  // for performance reasons ensure that the entire DOM is not traversed
   __warnings = [];
   axs.Audit.run(auditConfig);
 
@@ -144,6 +149,7 @@ test("Unsupported Rules Warning not shown if showUnsupportedRulesWarning set to 
 
 test("Unsupported Rules Warning not shown if with console API on configuration set", function() {
   var auditConfig = new axs.AuditConfiguration();
+  auditConfig.walkDom = false;  // for performance reasons ensure that the entire DOM is not traversed
   auditConfig.withConsoleApi = true;
   // This should not be touched by an end-user, but needs to be set here,
   // because the unit tests run multiple times Audit.run()
@@ -172,6 +178,7 @@ test("Configure LinkWithUnclearPurpose: blacklist phrase", function() {
 
   var auditConfig = new axs.AuditConfiguration();
   auditConfig.scope = fixture;
+  auditConfig.walkDom = false;
 
   var results = axs.Audit.run(auditConfig);
   equal(results.some(function(result) {
@@ -236,6 +243,7 @@ test("Configure LinkWithUnclearPurpose: stopwords", function() {
 
   var auditConfig = new axs.AuditConfiguration();
   auditConfig.scope = fixture;
+  auditConfig.walkDom = false;
 
   var results = axs.Audit.run(auditConfig);
   equal(results.some(function(result) {

--- a/test/js/audit-configuration-test.js
+++ b/test/js/audit-configuration-test.js
@@ -48,7 +48,7 @@ test("Configure severity of an audit rule", function() {
 
 test("Specify configuration as an object", function() {
   var fixtures = document.getElementById('qunit-fixture');
-  
+
   var configPayload = {
     auditRulesToRun: ['badAriaRole'],
     scope: fixtures,
@@ -119,10 +119,10 @@ test("Unsupported Rules Warning shown first and only first time audit ran", func
   // because the unit tests run multiple times Audit.run()
   axs.Audit.unsupportedRulesWarningShown = false;
   __warnings = [];
-  axs.Audit.run();
+  axs.Audit.run(auditConfig);
 
   equal(2, __warnings.length);
-  axs.Audit.run();
+  axs.Audit.run(auditConfig);
   equal(2, __warnings.length);
 });
 

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -16,7 +16,8 @@ QUnit.extend(QUnit.assert, {
         var ruleName = config.ruleName;
         var auditConfig = new axs.AuditConfiguration({
             auditRulesToRun: [ruleName],
-            scope: config.scope || document.getElementById('qunit-fixture')
+            scope: config.scope || document.getElementById('qunit-fixture'),
+            walkDom: false  // In QUnit tests we never need to walk the entire DOM
         });
         if (config.ignoreSelectors)
             auditConfig.ignoreSelectors(ruleName, config.ignoreSelectors);

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,0 +1,34 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+QUnit.extend(QUnit.assert, {
+    runRule: function(config, message) {
+        var ruleName = config.ruleName;
+        var auditConfig = new axs.AuditConfiguration({
+            auditRulesToRun: [ruleName],
+            scope: config.scope || document.getElementById('qunit-fixture')
+        });
+        if (config.ignoreSelectors)
+            auditConfig.ignoreSelectors(ruleName, config.ignoreSelectors);
+        var actual = axs.Audit.run(auditConfig);
+        this.equal(actual.length, 1, 'Only one rule should have run');
+        var result = actual[0];
+        this.equal(result.rule.name, ruleName, 'The correct rule should have run');
+        if (message)
+            this.equal(result.result, config.expected, message);
+        else
+            this.equal(result.result, config.expected);
+        if (config.elements)
+            this.deepEqual(result.elements, config.elements, 'The correct number of elements should be included');
+    }
+});


### PR DESCRIPTION
- Begins to address #263. There are definitely more optimizations to make but this is already a large PR.
- Addresses a TODO, namely expanding AX_ARIA_02 so that it covers HTML attributes as well as ARIA attributes.
- Fixed some style nits while I was there

Hopefully the performance improvement works on other pages (and hopefully you are happy with the changes).

Here are the results on my test page, using `console.time` (no audits disabled, includes DuplicateID):

Before: 7 seconds
After: 2 seconds (70% faster)

@alice PTAL and sorry it's a big one to review! There's about 40 hours work in it.