### PR TITLE
Update submodule to use latest closure-library on GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/closure-library"]
 	path = lib/closure-library
-	url = https://code.google.com/p/closure-library/
+	url = https://github.com/google/closure-library


### PR DESCRIPTION
Hi there,

When trying to do a recursive clone I ran into this message:

```
Cloning into 'lib/closure-library'...
fatal: repository 'https://code.google.com/p/closure-library/' not found
Clone of 'https://code.google.com/p/closure-library/' into submodule path 'lib/closure-library' failed
```

So I just updated the submodule to point to the new repo on Google with the latest sha.

