### PR TITLE
Update closure-library url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/closure-library"]
 	path = lib/closure-library
-	url = https://code.google.com/p/closure-library/
+	url = https://github.com/google/closure-library


### PR DESCRIPTION
Git submodule doesn't resolve to https://code.google.com/p/closure-library/ https://github.com/google/closure-library, so you get errors like
```
fatal: repository 'https://code.google.com/p/closure-library/' not found
fatal: clone of 'https://code.google.com/p/closure-library/' into submodule path '/Users/zhian/accessibility-developer-tools/lib/closure-library' failed
```