### PR TITLE
Make the npm module requireable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
         options: {
             configFile: '.eslintrc'
         },
-        target: ['./src/js/', './src/audits/']
+        target: ['./src/js/', './src/audits/', './Gruntfile.js', './main.js']
     },
 
     prompt: {

--- a/main.js
+++ b/main.js
@@ -1,0 +1,7 @@
+// This exposes the ./dist Javascript file for node libraries.
+// It also unwraps the main axs package so Audit and other objects are exposed
+// directly in the node library
+
+var library = require('./dist/js/axs_testing'); // eslint-disable-line no-undef
+
+module.exports = library.axs; // eslint-disable-line no-undef

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/GoogleChrome/accessibility-developer-tools/issues"
   },
   "homepage": "https://github.com/GoogleChrome/accessibility-developer-tools",
-  "main": "src/js/Audit.js",
+  "main": "dist/js/axs_testing.js",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/GoogleChrome/accessibility-developer-tools/issues"
   },
   "homepage": "https://github.com/GoogleChrome/accessibility-developer-tools",
-  "main": "dist/js/axs_testing.js",
+  "main": "main.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
First, thanks for a wonderful library! I'm using it to automatically test our website (https://openstax.org) and was not happy with shoehorning [squizlabs/HTML_CodeSniffer](https://github.com/squizlabs/HTML_CodeSniffer) to run automatically.

The first commit just changes `package.json` to expose the `dist/js/axs_testing.js` file for node users which is the bulk of getting it to work.

The second commit unwraps the `axs` package to expose the `Audit*` objects directly so you can write something like:

```js
var axs = require('accessibility-developer-tools');
axs.Audit.run();
```

If you would prefer just the 1st commit I can happily revert the second commit or change anything else 😄 . Thanks again!