### PR TITLE
adds selectors to the Audit results

### DIFF
--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -232,6 +232,7 @@ axs.Audit.getRulesCannotRun = function(opt_configuration) {
  *     {
  *       result,    // @type {axs.constants.AuditResult}
  *       elements,  // @type {Array.<Element>}
+ *       selectors, // @type {Array.<String>}
  *       rule       // @type {axs.AuditRule} - data only (name, severity, code)
  *     }
  */

--- a/src/js/AuditRule.js
+++ b/src/js/AuditRule.js
@@ -217,12 +217,14 @@ axs.AuditRule.Result.prototype.update = function(auditResult, element) {
     var result = this;
     if (auditResult === axs.constants.AuditResult.FAIL) {
         var failingElements = result.elements || (result.elements = []);
+        var failingSelectors = result.selectors || (result.selectors = []);
         result.result = auditResult;  // If FAIL then we change the result to FAIL no matter what it is
         if (this.maxResults && result.elements.length >= this.maxResults) {
             result.resultsTruncated = true;
         } else if (element) {
             // element should always be defined here but testing first avoids pushing undefined onto the array
             failingElements.push(element);
+            failingSelectors.push(axs.utils.getQuerySelectorText(element))
         }
     } else if (auditResult === axs.constants.AuditResult.PASS) {
         if (!result.elements)

--- a/test/js/audit-configuration-test.js
+++ b/test/js/audit-configuration-test.js
@@ -111,6 +111,32 @@ test('Configure audit rules to ignore', function() {
 
 });
 
+test("Check that selectors are returned in the results", function() {
+  var fixture = document.getElementById('qunit-fixture');
+  var div = document.createElement('div');
+  div.setAttribute('role', 'not-an-aria-role');
+  fixture.appendChild(div);
+  var div2 = document.createElement('div');
+  div2.setAttribute('role', 'also-not-an-aria-role');
+  fixture.appendChild(div2);
+  var auditConfig = new axs.AuditConfiguration();
+  auditConfig.auditRulesToRun = ['badAriaRole'];
+  auditConfig.scope = fixture;  // limit scope to just fixture element
+  auditConfig.walkDom = false;
+
+  var results = axs.Audit.run(auditConfig);
+  equal(results.length, 1);
+  equal(results[0].selectors.length, 2);
+  equal(results[0].selectors[0], '#qunit-fixture > DIV');
+  equal(results[0].selectors[1], '#qunit-fixture > DIV:nth-of-type(2)');
+
+  auditConfig.maxResults = 1;
+  results = axs.Audit.run(auditConfig);
+  equal(results.length, 1);
+  equal(results[0].selectors.length, 1);
+  equal(results[0].selectors[0], '#qunit-fixture > DIV');
+});
+
 var __warnings = [];
 console.warn = function(msg) {
   __warnings.push(msg);


### PR DESCRIPTION
This adds an additional field to the Audit results object which provides an array of selectors that were found. I added it as an additional field to maintain backwards-compatibility with previous versions.

Some use-cases for adding selectors:

- running audits as a part of unit/integration tests could use the selector to provide a more helpful message (see electron/spectron#126)
- tools like [electron/devtron#87](https://github.com/electron/devtron/pull/87#issuecomment-250211769) could use the selector directly to `inspect(...)` an element when clicked

# Question

1. Since `getQuerySelectorText(element)` does not always generate a valid selector, should it be configured in the `AuditConfig` via something like `config.includeSelectors = true`?
