### PR TITLE
Update `composedParentNode` for Shadow DOM v1.

### DIFF
--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -70,9 +70,15 @@ axs.dom.composedParentNode = function(node) {
     if (!parentNode.shadowRoot)
         return parentNode;
 
-    var insertionPoints = node.getDestinationInsertionPoints();
-    if (insertionPoints.length > 0)
-        return axs.dom.composedParentNode(insertionPoints[insertionPoints.length - 1]);
+    var assignedSlot = node.assignedSlot;
+    if (assignedSlot)
+        return axs.dom.composedParentNode(assignedSlot);
+
+    if ('getDestinationInsertionPoints' in node) {
+        var insertionPoints = node.getDestinationInsertionPoints();
+        if (insertionPoints.length > 0)
+            return axs.dom.composedParentNode(insertionPoints[insertionPoints.length - 1]);
+    }
 
     return null;
 };

--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -70,13 +70,15 @@ axs.dom.composedParentNode = function(node) {
     if (!parentNode.shadowRoot)
         return parentNode;
 
+    // Shadow DOM v1
     if (node.nodeType === Node.ELEMENT_NODE || node.nodeType === Node.TEXT_NODE) {
       var assignedSlot = node.assignedSlot;
-      if (assignedSlot)
+      if (HTMLSlotElement && assignedSlot instanceof HTMLSlotElement)
           return axs.dom.composedParentNode(assignedSlot);
     }
 
-    if ('getDestinationInsertionPoints' in node) {
+    // Shadow DOM v0
+    if (typeof node.getDestinationInsertionPoints === 'function') {
         var insertionPoints = node.getDestinationInsertionPoints();
         if (insertionPoints.length > 0)
             return axs.dom.composedParentNode(insertionPoints[insertionPoints.length - 1]);

--- a/src/js/DOMUtils.js
+++ b/src/js/DOMUtils.js
@@ -70,9 +70,11 @@ axs.dom.composedParentNode = function(node) {
     if (!parentNode.shadowRoot)
         return parentNode;
 
-    var assignedSlot = node.assignedSlot;
-    if (assignedSlot)
-        return axs.dom.composedParentNode(assignedSlot);
+    if (node.nodeType === Node.ELEMENT_NODE || node.nodeType === Node.TEXT_NODE) {
+      var assignedSlot = node.assignedSlot;
+      if (assignedSlot)
+          return axs.dom.composedParentNode(assignedSlot);
+    }
 
     if ('getDestinationInsertionPoints' in node) {
         var insertionPoints = node.getDestinationInsertionPoints();

--- a/src/js/externs/externs.js
+++ b/src/js/externs/externs.js
@@ -30,3 +30,14 @@ ShadowRoot.prototype.olderShadowRoot;
  * @type {HTMLShadowElement}
  */
 HTMLElement.prototype.webkitShadowRoot;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLSlotElement() {}
+
+/**
+ * @return {?HTMLSlotElement}
+ */
+HTMLElement.prototype.assignedSlot = function() {};

--- a/src/js/externs/externs.js
+++ b/src/js/externs/externs.js
@@ -38,6 +38,15 @@ HTMLElement.prototype.webkitShadowRoot;
 function HTMLSlotElement() {}
 
 /**
+ * @constructor
+ */
+function Slotable() {};
+
+/**
  * @return {?HTMLSlotElement}
  */
-HTMLElement.prototype.assignedSlot = function() {};
+Slotable.prototype.assignedSlot = function() {};
+
+Element.prototype.assignedSlot = Slotable.prototype.assignedSlot;
+
+Text.prototype.assignedSlot = Slotable.prototype.assignedSlot;

--- a/src/js/externs/externs.js
+++ b/src/js/externs/externs.js
@@ -38,15 +38,11 @@ HTMLElement.prototype.webkitShadowRoot;
 function HTMLSlotElement() {}
 
 /**
- * @constructor
+ * @return {?HTMLSlotElement}
  */
-function Slotable() {};
+Element.prototype.assignedSlot = function() {};
 
 /**
  * @return {?HTMLSlotElement}
  */
-Slotable.prototype.assignedSlot = function() {};
-
-Element.prototype.assignedSlot = Slotable.prototype.assignedSlot;
-
-Text.prototype.assignedSlot = Slotable.prototype.assignedSlot;
+Text.prototype.assignedSlot = function() {};

--- a/test/js/composed-parent-node-test.js
+++ b/test/js/composed-parent-node-test.js
@@ -30,7 +30,12 @@
         var fixture = document.getElementById('qunit-fixture');
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            equal(axs.dom.composedParentNode(root), host);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             equal(axs.dom.composedParentNode(root), host);
         } else {
@@ -44,7 +49,14 @@
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
         var testElement = host.appendChild(document.createElement('span'));
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var slot = document.createElement('slot');
+            root.appendChild(slot);
+            equal(axs.dom.composedParentNode(testElement), host);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var content = document.createElement('content');
             root.appendChild(content);
@@ -60,7 +72,15 @@
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
         var testElement = host.appendChild(document.createElement('span'));
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var shadowParent = root.appendChild(document.createElement('div'));
+            shadowParent.id = 'shadowParent';
+            var slot = shadowParent.appendChild(document.createElement('slot'));
+            equal(axs.dom.composedParentNode(testElement), shadowParent);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var shadowParent = root.appendChild(document.createElement('div'));
             shadowParent.id = 'shadowParent';
@@ -77,7 +97,19 @@
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
         var testElement = host.appendChild(document.createElement('span'));
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var outerRoot = host.attachShadow({mode: 'open'});
+            var shadowGrandparent = outerRoot.appendChild(document.createElement('div'));
+            shadowGrandparent.id = 'shadowGrandparent';
+            var outerSlot = shadowGrandparent.appendChild(document.createElement('slot'));
+            var innerRoot = shadowGrandparent.attachShadow({mode: 'open'});
+            var shadowParent = innerRoot.appendChild(document.createElement('div'));
+            shadowParent.id = 'shadowParent';
+            var innerSlot = shadowParent.appendChild(document.createElement('slot'));
+            equal(axs.dom.composedParentNode(testElement), shadowParent);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var outerRoot = host.createShadowRoot();
             var shadowGrandparent = outerRoot.appendChild(document.createElement('div'));
             shadowGrandparent.id = 'shadowGrandparent';
@@ -99,7 +131,15 @@
         host.id = 'host';
         var testElement = host.appendChild(document.createElement('span'));
         testElement.id = 'test';
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var slot = root.appendChild(document.createElement('slot'));
+            slot.name = 'A';
+            testElement.slot = 'B';
+            equal(axs.dom.composedParentNode(testElement), null);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var content = root.appendChild(document.createElement('content'));
             content.select = 'div';
@@ -116,7 +156,18 @@
         host.id = 'host';
         var testElement = host.appendChild(document.createElement('span'));
         testElement.id = 'test';
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var slot1 = root.appendChild(document.createElement('slot'));
+            slot1.name = 'A';
+            var slot2 = root.appendChild(document.createElement('slot'));
+            slot2.name = 'B';
+            testElement.slot = 'B';
+
+            equal(axs.dom.composedParentNode(testElement), host);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var content1 = root.appendChild(document.createElement('content'));
             content1.select = 'div';
@@ -136,7 +187,20 @@
         host.id = 'host';
         var testElement = host.appendChild(document.createElement('span'));
         testElement.id = 'test';
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var shadowParent = root.appendChild(document.createElement('div'));
+            shadowParent.id = 'shadowParent';
+            var slot1 = root.appendChild(document.createElement('slot'));
+            slot1.name = 'A';
+            var slot2 = shadowParent.appendChild(document.createElement('slot'));
+            slot2.name = 'B';
+            testElement.slot = 'B';
+
+            equal(axs.dom.composedParentNode(testElement), shadowParent);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var shadowParent = root.appendChild(document.createElement('div'));
             shadowParent.id = 'shadowParent';
@@ -156,7 +220,13 @@
         var fixture = document.getElementById('qunit-fixture');
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var shadowChild = root.appendChild(document.createElement('div'));
+            equal(axs.dom.composedParentNode(shadowChild), host);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var shadowChild = root.appendChild(document.createElement('div'));
             equal(axs.dom.composedParentNode(shadowChild), host);
@@ -171,11 +241,20 @@
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
         var lightChild = host.appendChild(document.createElement('span'));
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var shadowChild = root.appendChild(document.createElement('div'));
+            shadowChild.id = 'shadowChild';
+            equal(axs.dom.composedParentNode(lightChild), null);
+            equal(axs.dom.composedParentNode(shadowChild), host);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var shadowChild = root.appendChild(document.createElement('div'));
             shadowChild.id = 'shadowChild';
             equal(axs.dom.composedParentNode(lightChild), null);
+            equal(axs.dom.composedParentNode(shadowChild), host);
         } else {
             console.warn('Test platform does not support shadow DOM');
             ok(true);
@@ -187,7 +266,17 @@
         var host = fixture.appendChild(document.createElement('div'));
         host.id = 'host';
         var lightChild = host.appendChild(document.createElement('div'));
-        if (host.createShadowRoot) {
+        if (host.attachShadow) {
+            // Shadow DOM v1
+            var root = host.attachShadow({mode: 'open'});
+            var shadowChild = document.createElement('div');
+            shadowChild.id = 'shadowChild';
+            root.appendChild(shadowChild);
+            var slot = document.createElement('slot');
+            root.appendChild(slot);
+            equal(axs.dom.composedParentNode(lightChild), host);
+        } else if (host.createShadowRoot) {
+            // Shadow DOM v0
             var root = host.createShadowRoot();
             var shadowChild = document.createElement('div');
             shadowChild.id = 'shadowChild';


### PR DESCRIPTION
This PR updates `axs.dom.composedParentNode` to use `assignedSlot` (new in Shadow DOM v1, [link](https://github.com/w3c/webcomponents/commit/224f6b8e1e48f5db0a592ec8fb5162770062be24)) if available and doesn't attempt to call `getDestinationInsertionPoints` (removed) if it isn't available.

Some of the tests specifically check the behavior of content elements with a set `select` attribute; I changed these to use slots with `name` attributes and added `slot` attributes to the relevant nodes outside the shadow tree to get the same 'distributed vs. not distributed' behavior. It might be worth renaming the tests since they're not about content elements anymore.

(fixes #312)
