### PR TITLE
Delete the main file and export the axs_testing from dist as main file

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,0 @@
-// This exposes the ./dist Javascript file for node libraries.
-// It also unwraps the main axs package so Audit and other objects are exposed
-// directly in the node library
-
-var library = require('./dist/js/axs_testing'); // eslint-disable-line no-undef
-
-module.exports = library.axs; // eslint-disable-line no-undef

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/GoogleChrome/accessibility-developer-tools/issues"
   },
   "homepage": "https://github.com/GoogleChrome/accessibility-developer-tools",
-  "main": "main.js",
+  "main": "dist/js/axs_testing",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
The main file for NPM currently exports `undefined` because of a change in the library. 

By directly using the axs_testing file from the dist/ directory as the main file the while object is exported instead of an undefined attribute.