### PR TITLE
specify support of ShadowRoot

### DIFF
--- a/src/js/Properties.js
+++ b/src/js/Properties.js
@@ -175,7 +175,7 @@ axs.properties.hasDirectTextDescendant = function(element) {
         while (treeWalker.nextNode()) {
             var resultElement = treeWalker.currentNode;
             var parent = resultElement.parentNode;
-            // Handle elements hosted in <template>.content.
+            // Handle elements hosted in ShadowRoots.
             parent = parent.host || parent;
             var tagName = parent.tagName.toLowerCase();
             var value = resultElement.nodeValue.trim();

--- a/test/js/properties-test.js
+++ b/test/js/properties-test.js
@@ -17,11 +17,14 @@ test("Find text descendants in an iframe.", function() {
     equal(axs.properties.hasDirectTextDescendant(foo), true);
 });
 
-test("Find text descendants in a <template>.", function() {
-    var templ = document.createElement('template');
-    templ.innerHTML = '<div>bar</div>';
-    // <template> might not be supported by the browser, test anyway.
-    var foo = (templ.content || templ).firstChild;
+test("Find text descendants in a ShadowRoot.", function() {
+    var host = document.createElement('div');
+    if (host.attachShadow) {
+        host = host.attachShadow({mode: 'open'});
+    }
+    var foo = document.createElement('div');
+    foo.textContent = 'bar';
+    host.appendChild(foo);
     equal(axs.properties.hasDirectTextDescendant(foo), true);
 });
 


### PR DESCRIPTION
https://github.com/GoogleChrome/accessibility-developer-tools/pull/338 actually provided support for elements hosted in a shadow root, not a `<template>`. This PR makes it more clear & updates the tests accordingly.
 
When an element is hosted in `<template>.content`, its `.parentNode` will be a `DocumentFragment`, and the fragment's `.host` will be `undefined`.
When an element is hosted in a `shadowRoot`, its `.parentNode` will be a `DocumentFragment`, and the fragment's `.host` will be the shadowRoot owner element 🎉 
 