### PR TITLE
Rule to check if a page has a sign language widget

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,7 @@ module.exports = function(grunt) {
               './src/js/AuditRules.js',
               './src/js/AuditResults.js',
               './src/js/Audit.js',
+              './src/audits/PageWithoutSignLanguageWidget.js',
               './src/audits/*'
           ]
         },

--- a/src/audits/PageWithoutSignLanguageWidget.js
+++ b/src/audits/PageWithoutSignLanguageWidget.js
@@ -1,0 +1,44 @@
+// Copyright 2013 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.require("axs.AuditRules");
+goog.require("axs.constants.Severity");
+
+axs.AuditRules.addRule({
+  name: "pageWithoutSignLanguageWidget",
+  heading: "The web page should have a sign language widget",
+  url: "https://mindrocketsinc.com/main/",
+  severity: axs.constants.Severity.WARNING,
+  relevantElementMatcher: function (element) {
+    return element.tagName.toLowerCase() == "html";
+  },
+  test: function (scope) {
+    var signLanguageWidget = scope.querySelectorAll("#DeafTranslate");
+    if (signLanguageWidget.length) return false;
+    signLanguageWidget = scope.querySelectorAll("#SignLanguage");
+    if (signLanguageWidget.length) return false;
+    signLanguageWidget = scope.querySelectorAll(".sign-language");
+    if (signLanguageWidget.length) return false;
+    signLanguageWidget = scope.querySelectorAll(".mr-tooltip");
+    if (signLanguageWidget.length) return false;
+    signLanguageWidget = scope.querySelectorAll("[alt='DEAF']");
+    if (signLanguageWidget.length) return false;
+
+    signLanguageWidget = scope.querySelectorAll(
+      'script[src*="/integrator.js"],script[src*="/tooltip_add.js"],script[src*="/signsplayer.js"]'
+    );
+    return !signLanguageWidget.length;
+  },
+  code: "AX_SIGNLANG_01",
+});

--- a/test/audits/page-without-sign-language-widget.js
+++ b/test/audits/page-without-sign-language-widget.js
@@ -1,0 +1,35 @@
+module("Page Sign Language");
+/*
+  test: function (scope) {
+    var signLanguageWidget = scope.querySelectorAll("#DeafTranslate");
+    if (signLanguageWidget.length) return false;
+    var signLanguageWidget = scope.querySelectorAll("#SignLanguage");
+    if (signLanguageWidget.length) return false;
+    var signLanguageWidget = scope.querySelectorAll(".sign-language");
+    if (signLanguageWidget.length) return false;
+    var signLanguageWidget = scope.querySelectorAll(".mr-tooltip");
+    return !signLanguageWidget.length;
+*/
+test("Page must have a sign language widget", function (assert) {
+  // Remove the title element from the qunit test page.
+  var deaf = document.querySelector("#DeafTranslate");
+  if (deaf && deaf.parentNode) deaf.parentNode.removeChild(deaf);
+
+  var config = {
+    scope: document.documentElement,
+    ruleName: "pageWithoutSignLanguageWidget",
+    expected: axs.constants.AuditResult.FAIL,
+  };
+
+  var deafElm = document.createElement("div");
+  deafElm.id = "DeafTranslate";
+  var config = {
+    scope: document.documentElement,
+    ruleName: "pageWithoutSignLanguageWidget",
+    expected: axs.constants.AuditResult.PASS,
+  };
+  // This one fails because there is no title element.
+  assert.runRule(config);
+  var deaf = document.querySelector("#DeafTranslate");
+  if (deaf && deaf.parentNode) deaf.parentNode.removeChild(deaf);
+});

--- a/test/index.html
+++ b/test/index.html
@@ -29,6 +29,7 @@
     <script src="../src/audits/ControlsWithoutLabel.js"></script>
     <script src="../src/audits/TableHasAppropriateHeaders.js"></script>
     <script src="../src/audits/DuplicateId.js"></script>
+    <script src="../src/audits/PageWithoutSignLanguageWidget.js"></script>
     <script src="../src/audits/FocusableElementNotVisibleAndNotAriaHidden.js"></script>
     <script src="../src/audits/ImageWithoutAltText.js"></script>
     <script src="../src/audits/LinkWithUnclearPurpose.js"></script>
@@ -67,6 +68,7 @@
     <script src="./audits/controls-without-label-test.js"></script>
     <script src="./audits/data-table-headers-missing-test.js"></script>
     <script src="./audits/duplicate-id-test.js"></script>
+    <script src="./audits/page-without-sign-language-widget.js"></script>
     <script src="./audits/image-without-alt-text-test.js"></script>
     <script src="./audits/focusable-element-not-visible-not-aria-hidden-test.js"></script>
     <script src="./audits/link-with-unclear-purpose.js"></script>


### PR DESCRIPTION
This rule is implemented currently for the Mind Rockets Sign Language Widget, but it could also be extended in the future for other automated Sign Language widgets. In addition, it checks if there are any tags in the page which detects the page has anything related to deaf or sign language.